### PR TITLE
Firearm Rebalance, part 1: ballistics.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/antimateriel.yml
@@ -45,7 +45,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 75
+        Piercing: 80 #RATT
+        Structural: 150 #RATT, WHY DIDN'T ANTI MATERIEL NOT HAVE STRUCTURE DAMAGE?
       armorPenetration: 0.5 # Goobstation
     penetrationThreshold: 100 # Goobstation - This count as penetration health
   - type: StaminaDamageOnCollide

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -35,7 +35,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 25 # Goobstation edit
+        Piercing: 28 #RATT
       armorPenetration: -0.3 # Goobstation
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -22,7 +22,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 26 #RATT
 
 - type: entity
   id: BulletMinigun
@@ -33,4 +33,4 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 5
+        Piercing: 7 #RATT

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/light_rifle.yml
@@ -40,7 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 19
+        Piercing: 25 #RATT
       armorPenetration: 0.4 # Goobstation
 
 - type: entity
@@ -76,4 +76,4 @@
     damage:
       types:
         Radiation: 10
-        Piercing: 11
+        Piercing: 18 #RATT

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -47,7 +47,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 40 #RATT
 
 - type: entity
   id: BulletMagnumPractice
@@ -69,8 +69,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 7
-        Heat: 7
+        Blunt: 8 #RATT
+        Heat: 8 #RATT
 
 - type: entity
   id: BulletMagnumAP
@@ -81,7 +81,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 28 # Goobstation edit
+        Piercing: 38 #RATT
       armorPenetration: 0.75 # Goobstation
 
 - type: entity
@@ -94,4 +94,4 @@
     damage:
       types:
         Radiation: 15
-        Piercing: 20
+        Piercing: 30 #RATT

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -36,7 +36,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 16
+        Piercing: 25 #RAT
 
 - type: entity
   id: BulletPistolPractice
@@ -58,8 +58,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 2
-        Heat: 2
+        Blunt: 4 #RAT
+        Heat: 4 #RAT
 
 - type: entity
   id: BulletPistolUranium
@@ -70,5 +70,5 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 6
-        Piercing: 10
+        Radiation: 10 #RAT
+        Piercing: 20 #RAT

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -40,7 +40,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 17
+        Piercing: 26
       armorPenetration: 0.15 # Goobstation
 
 - type: entity
@@ -75,5 +75,5 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 9
-        Piercing: 10
+        Radiation: 13
+        Piercing: 16

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -117,8 +117,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 40
-        Structural: 15
+        Piercing: 60 #RATT
+        Structural: 30 #RATTT
 
 
 - type: entity
@@ -149,8 +149,8 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10
-        Structural: 15
+        Piercing: 12 #RATT
+        Structural: 18 #RATT
 
 
 - type: entity


### PR DESCRIPTION
Focuses on boosting ballistics firing power, all balanced around:
![image](https://github.com/user-attachments/assets/2eadf842-51fd-4ba1-a9cc-1b3c9772226f)
> .35 auto
.35 auto does 25 pierce instead of 16
.35 incid does 4/4 blunt and head instead of 2/2
.35 uranium does 10/20 rad pierce instead of 6/10
> .20 rifle
.20 rifle does 26 pierce instead of 17 
.20 uranium does 13/16 rad pierce instead of 9/10
> .50
Slugs now do 60/30 pierce strut instead of 40/15. Rewarding the peircise aim needed for slugs.
Buckshot now does 12/18 pierce strut instead of 10/15
> .45
45 mag now does 40 pierce instead of 35
.45 incid now does 8/8 blunt heat instead of 7/7
.45 AP now does 38 pierce instead of 28 (may need tweaking)
.45 uranium now does 10 more pierce.
>.30 rifle
.30 now does 25 pierce instead of 19 (may need increase)
.30 uranium does 7 more pierce.
> heavy rifle is admin only i think so just read yourself in heavy_rifle.yml
> .60 AM
IT WAS SO WEAKKKKK
GIGA BUFFED AM FROM 75 to 80 PIERCE, WHILST ADDING 150 STRUT DAMAGE (1 and 1/2 walls) 
SERIOUSLY AN ANTI MATERIEL RIFLE DIDNT DO MATERIEL DAMAGE???
> 9.5mm HP
does 3 more damage... (defo need buff prob but its never used anyway cause viper exists...)
