### PR TITLE
should be nuked.

### DIFF
--- a/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
+++ b/Content.Goobstation.Common/CCVar/CCVars.Goob.cs
@@ -473,7 +473,7 @@ public sealed partial class GoobCVars
         CVarDef.Create("voice.hear_self", false, CVar.CLIENTONLY | CVar.ARCHIVE, "Whether to hear audio from your own entity.");
 
     #endregion
-    
+
     #region Queue
 
     /// <summary>
@@ -555,7 +555,7 @@ public sealed partial class GoobCVars
     /// Minimum velocity difference between 2 bodies for a shuttle impact to be guaranteed to trigger any special behaviors like damage.
     /// </summary>
     public static readonly CVarDef<float> MinimumImpactVelocity =
-        CVarDef.Create("shuttle.impact.minimum_velocity", 15f, CVar.SERVERONLY); // needed so that random space debris can be rammed
+        CVarDef.Create("shuttle.impact.minimum_velocity", 1500f, CVar.SERVERONLY); // RATT, theoreticly makes shuttleramming impossible.
 
     /// <summary>
     /// Multiplier of Kinetic energy required to dismantle a single tile in relation to its mass


### PR DESCRIPTION
Nuked shuttle collision by making it so you need to be going the speed of fucking light to have any damage calcs triggered.

> Changes CCVARS
> changed mimimum speed from 15 to 1500, practicly unreachable.