### PR TITLE
The great CCVAR changes.

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -72,7 +72,7 @@ public sealed partial class CCVars
     ///     Controls the maximum number of character slots a player is allowed to have.
     /// </summary>
     public static readonly CVarDef<int>
-        GameMaxCharacterSlots = CVarDef.Create("game.maxcharacterslots", 30, CVar.ARCHIVE | CVar.SERVERONLY);
+        GameMaxCharacterSlots = CVarDef.Create("game.maxcharacterslots", 50, CVar.ARCHIVE | CVar.SERVERONLY); ///Ratbites, more characters doesn't hurt.
 
     /// <summary>
     ///     Controls the game map prototype to load. SS14 stores these prototypes in Prototypes/Maps.
@@ -134,7 +134,7 @@ public sealed partial class CCVars
     ///     Whether or not disconnecting inside of a cryopod should remove the character or just store them until they reconnect.
     /// </summary>
     public static readonly CVarDef<bool>
-        GameCryoSleepRejoining = CVarDef.Create("game.cryo_sleep_rejoining", false, CVar.SERVER | CVar.REPLICATED);
+        GameCryoSleepRejoining = CVarDef.Create("game.cryo_sleep_rejoining", true, CVar.SERVER | CVar.REPLICATED); ///Ratbites, being able to safely go afk is nice.
 
     /// <summary>
     ///     When enabled, guests will be assigned permanent UIDs and will have their preferences stored.
@@ -357,7 +357,7 @@ public sealed partial class CCVars
     ///     Defaults to 2 minutes.
     /// </summary>
     public static readonly CVarDef<float> RoundRestartTime =
-        CVarDef.Create("game.round_restart_time", 120f, CVar.SERVERONLY);
+        CVarDef.Create("game.round_restart_time", 100f, CVar.SERVERONLY); ///Ratbites, roundend people tend to all be dead by 1m, this shortens restart by 20s.
 
     /// <summary>
     ///     The prototype to use for secret weights.

--- a/Content.Shared/CCVar/CCVars.Ghost.cs
+++ b/Content.Shared/CCVar/CCVars.Ghost.cs
@@ -13,7 +13,7 @@ public sealed partial class CCVars
     ///     The time you must spend reading the rules, before the "Request" button is enabled
     /// </summary>
     public static readonly CVarDef<float> GhostRoleTime =
-        CVarDef.Create("ghost.role_time", 3f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("ghost.role_time", 1f, CVar.REPLICATED | CVar.SERVER); ///Ratbites, selfantag being allowed means the ghostrole rules mainly are nothingburger and metagrudging is covered already.
 
     /// <summary>
     ///     If ghost role lotteries should be made near-instanteous.

--- a/Content.Shared/CCVar/CCVars.Ic.cs
+++ b/Content.Shared/CCVar/CCVars.Ic.cs
@@ -13,19 +13,19 @@ public sealed partial class CCVars
     ///     Restricts IC character names to alphanumeric chars.
     /// </summary>
     public static readonly CVarDef<bool> RestrictedNames =
-        CVarDef.Create("ic.restricted_names", true, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("ic.restricted_names", false, CVar.SERVER | CVar.REPLICATED); /// Ratbites, the new character freedom is here.
 
     /// <summary>
     ///     Allows flavor text (character descriptions)
     /// </summary>
     public static readonly CVarDef<bool> FlavorText =
-        CVarDef.Create("ic.flavor_text", false, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("ic.flavor_text", true, CVar.SERVER | CVar.REPLICATED); /// Ratbites, the new character freedom is here.
 
     /// <summary>
     ///     Adds a period at the end of a sentence if the sentence ends in a letter.
     /// </summary>
     public static readonly CVarDef<bool> ChatPunctuation =
-        CVarDef.Create("ic.punctuation", false, CVar.SERVER);
+        CVarDef.Create("ic.punctuation", true, CVar.SERVER); ///Ratbites, ease of life.
 
     /// <summary>
     ///     Enables automatically forcing IC name rules. Uppercases the first letter of the first and last words of the name
@@ -63,5 +63,5 @@ public sealed partial class CCVars
     ///     Won't work without ICSSDSleep
     /// </summary>
     public static readonly CVarDef<float> ICSSDSleepTime =
-        CVarDef.Create("ic.ssd_sleep_time", 600f, CVar.SERVER);
+        CVarDef.Create("ic.ssd_sleep_time", 120f, CVar.SERVER); ///Ratbites, sleepy.
 }

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -24,7 +24,7 @@ public sealed partial class CCVars
     ///     Disabled: Cloning has full biomass cost and reclaimer can reclaim corpses with souls. (Playtested and balanced for MRP+).
     /// </summary>
     public static readonly CVarDef<bool> BiomassEasyMode =
-        CVarDef.Create("biomass.easy_mode", true, CVar.SERVERONLY);
+        CVarDef.Create("biomass.easy_mode", true, CVar.SERVERONLY); ///We could probably disable this.
 
     /// <summary>
     ///     A scale factor applied to a grid's bounds when trying to find a spot to randomly generate an anomaly.

--- a/Content.Shared/CCVar/CCVars.Tips.cs
+++ b/Content.Shared/CCVar/CCVars.Tips.cs
@@ -41,5 +41,5 @@ public sealed partial class CCVars
     ///     The chance for Tippy to replace a normal tip message.
     /// </summary>
     public static readonly CVarDef<float> TipsTippyChance =
-        CVarDef.Create("tips.tippy_chance", 0.01f);
+        CVarDef.Create("tips.tippy_chance", 0.1f); /// Ratbites, Tippy is based, you cant convince me otherwise.
 }


### PR DESCRIPTION
Adds IC flavour text, name customisation, allows you to have 50 characters!
Also, SSD people will fall asleep after 100 seconds and punction autocorrect has been added, a peroid will appear if your sentance ends in a letter!

For none character related things:
Shortens roundrestart by 20 seconds. Making it 1:40 after the evac shuttle arrives at centcom. Should make it less boring for those who are dead on arrival or aftermath of nukies.
Shortened the time from 3 seconds to 1 second to accept the ghost role rules, we all have read these a million times and the rules for ghostroles are covered in server rules anyway.
Tippy chance increased.