### PR TITLE
Added FiringPinComponent and FiringPinSystem

### DIFF
--- a/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.FiringPin;
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FiringPinComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Locked = true;
+}

--- a/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._BRatbite.FiringPin;
 
 /// <summary>
-/// This is used for...
+/// This is used for telling FiringPinSystem to acknowledge this as a mindshield restricted weapon
 /// </summary>
 [RegisterComponent, NetworkedComponent]
 public sealed partial class FiringPinComponent : Component

--- a/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinComponent.cs
@@ -5,9 +5,8 @@ namespace Content.Shared._BRatbite.FiringPin;
 /// <summary>
 /// This is used for...
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class FiringPinComponent : Component
 {
-    [DataField, AutoNetworkedField]
-    public bool Locked = true;
+
 }

--- a/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
@@ -1,5 +1,7 @@
+using Content.Shared.Lock;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Events;
 
 namespace Content.Shared._BRatbite.FiringPin;
@@ -18,7 +20,10 @@ public sealed class FiringPinSystem : EntitySystem
 
     private void OnShotAttempted(Entity<FiringPinComponent> ent, ref ShotAttemptedEvent args)
     {
-        if (!ent.Comp.Locked)
+        if (!TryComp<LockComponent>(ent, out var lockComponent))
+            return;
+
+        if (!lockComponent.Locked)
             return;
 
         if (HasComp<MindShieldComponent>(args.User))

--- a/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
 using Content.Shared.Weapons.Ranged.Events;
 
@@ -18,6 +19,9 @@ public sealed class FiringPinSystem : EntitySystem
     private void OnShotAttempted(Entity<FiringPinComponent> ent, ref ShotAttemptedEvent args)
     {
         if (!ent.Comp.Locked)
+            return;
+
+        if (HasComp<MindShieldComponent>(args.User))
             return;
 
         Popup.PopupClient(Loc.GetString("firing-pin-cant-fire"), ent, args.User);

--- a/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
+++ b/Content.Shared/_BRatbite/FiringPin/FiringPinSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Popups;
+using Content.Shared.Weapons.Ranged.Events;
+
+namespace Content.Shared._BRatbite.FiringPin;
+
+/// <summary>
+/// This handles whether a weapon with a FiringPinComponent should be allowed to fire
+/// </summary>
+public sealed class FiringPinSystem : EntitySystem
+{
+    [Dependency] protected readonly SharedPopupSystem Popup = default!;
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<FiringPinComponent, ShotAttemptedEvent>(OnShotAttempted);
+    }
+
+    private void OnShotAttempted(Entity<FiringPinComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (!ent.Comp.Locked)
+            return;
+
+        Popup.PopupClient(Loc.GetString("firing-pin-cant-fire"), ent, args.User);
+        args.Cancel();
+    }
+}

--- a/Resources/Locale/en-US/_BRatbite/firingpin/firing-pin.ftl
+++ b/Resources/Locale/en-US/_BRatbite/firingpin/firing-pin.ftl
@@ -1,4 +1,1 @@
-firing-pin-locked = You locked the firing pin
-firing-pin-unlocked = You unlocked the firing pin
-
-firing-pin-cant-fire = This gun is restricted access!
+firing-pin-cant-fire = This gun is restricted to mindshielded personal!

--- a/Resources/Locale/en-US/_BRatbite/firingpin/firing-pin.ftl
+++ b/Resources/Locale/en-US/_BRatbite/firingpin/firing-pin.ftl
@@ -1,0 +1,4 @@
+firing-pin-locked = You locked the firing pin
+firing-pin-unlocked = You unlocked the firing pin
+
+firing-pin-cant-fire = This gun is restricted access!

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -321,6 +321,11 @@
     - SemiAuto
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg
+  - type: FiringPin #Ratbite, mindshield restriction system
+  - type: Lock #Ratbite
+    locked: true
+  - type: AccessReader #Ratbite
+    access: [ [ "Security" ] ]
 
 - type: entity
   name: N1984

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -290,6 +290,12 @@
     steps: 1
     zeroVisible: true
   - type: Appearance
+  - type: FiringPin #Ratbite, mindshield restriction system
+  - type: Lock #Ratbite
+    locked: true
+  - type: AccessReader #Ratbite
+    access: [ [ "Security" ] ]
+
 
 - type: entity
   name: Foam Force Astro Ace

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -261,6 +261,11 @@
       - oni-cannot-shoot-guns-1
       - oni-cannot-shoot-guns-2
       - oni-cannot-shoot-guns-3
+    - type: FiringPin #Ratbite, mindshield restriction system
+    - type: Lock #Ratbite
+      locked: true
+    - type: AccessReader #Ratbite
+      access: [ [ "Security" ] ]
 
 - type: entity
   name: WT550 autorifle # Goobstation
@@ -326,3 +331,8 @@
   - type: Item
     shape:
     - 0,0,2,1
+  - type: FiringPin #Ratbite, mindshield restriction system
+  - type: Lock #Ratbite
+    locked: true
+  - type: AccessReader #Ratbite
+    access: [ [ "Security" ] ]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -232,6 +232,11 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 1.7 # Goobstation
+  - type: FiringPin #Ratbite, mindshield restriction system
+  - type: Lock #Ratbite
+    locked: true
+  - type: AccessReader #Ratbite
+    access: [ [ "Security" ] ]
 
 - type: entity
   parent: WeaponShotgunEnforcer
@@ -264,6 +269,11 @@
     - WeaponShotgunKammerer
   - type: BallisticAmmoProvider # Goobstation
     autoCycle: false
+  - type: FiringPin #Ratbite, mindshield restriction system
+  - type: Lock #Ratbite
+    locked: true
+  - type: AccessReader #Ratbite
+    access: [ [ "Security" ] ]
 
 - type: entity
   name: sawn-off shotgun


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Added a new component, FiringPinComponent, and system, FiringPinSystem. These prevent the firing of a weapon when an attached LockComponent is currently locked. Individuals with mindshield access can bypass the lock. AccessReaderComponent can limit who can lock and unlock.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Station standard armory weapons are now equipped with a mindshield check! Those with security access (or something that can break access systems) can disable this lock.
