### PR TITLE
Compatibility Mode Crash Fix

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -334,7 +334,7 @@
     maxDifficulty: 5
 
 # Goobstation - order swapped since admin verbs use .Last() for some reason
-# TODO: Fix that 
+# TODO: Fix that
 - type: entity
   id: TraitorReinforcement
   parent: BaseTraitorRuleNoObjectives # Goobstation
@@ -551,16 +551,16 @@
     - !type:NestedSelector
       tableId: BasicAntagEventsTable
 
-- type: entityTable
-  id: SpaceTrafficControlTable
-  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
-    children:
-      - !type:NestedSelector
-        tableId: UnknownShuttlesFriendlyTable
-      - !type:NestedSelector
-        tableId: UnknownShuttlesFreelanceTable
-      - !type:NestedSelector
-        tableId: UnknownShuttlesHostileTable
+#- type: entityTable  - Ratbite currently has no shuttle events
+#  id: SpaceTrafficControlTable
+#  table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
+#    children:
+#      - !type:NestedSelector
+#        tableId: UnknownShuttlesFriendlyTable
+#      - !type:NestedSelector
+#        tableId: UnknownShuttlesFreelanceTable
+#      - !type:NestedSelector
+#        tableId: UnknownShuttlesHostileTable
 
 - type: entity
   id: BasicStationEventScheduler
@@ -598,29 +598,29 @@
       tableId: BasicGameRulesTableNoAntag
 # goob edit end
 
-- type: entity
-  id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,
-  parent: BaseGameRule                  # we can remerge this with the other schedulers, but it will silently fail due to that limitation without a separate scheduler to balance atm.
-  components:
-  - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 2700 # 45 mins #shows up like half way through shift.
-    minMaxEventTiming:
-      min: 1200 # 20 mins
-      max: 7200 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
-    scheduledGameRules: !type:NestedSelector
-      tableId: SpaceTrafficControlTable
+#- type: entity  - Ratbite currently has no shuttle events
+#  id: SpaceTrafficControlEventScheduler # iff we make a selector for EntityTables that can respect StationEventComp restrictions, or somehow impliment them otherwise in said tables,
+#  parent: BaseGameRule                  # we can remerge this with the other schedulers, but it will silently fail due to that limitation without a separate scheduler to balance atm.
+#  components:
+#  - type: BasicStationEventScheduler
+#    minimumTimeUntilFirstEvent: 2700 # 45 mins #shows up like half way through shift.
+#    minMaxEventTiming:
+#      min: 1200 # 20 mins
+#      max: 7200 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
+#    scheduledGameRules: !type:NestedSelector
+#      tableId: SpaceTrafficControlTable
 
-- type: entity
-  id: SpaceTrafficControlFriendlyEventScheduler
-  parent: BaseGameRule
-  components:
-  - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 mins
-    minMaxEventTiming:
-      min: 600 # 10 mins
-      max: 1800 # 30 mins
-    scheduledGameRules: !type:NestedSelector
-      tableId: UnknownShuttlesFriendlyTable
+#- type: entity  - Ratbite currently has no shuttle events
+#  id: SpaceTrafficControlFriendlyEventScheduler
+#  parent: BaseGameRule
+#  components:
+#  - type: BasicStationEventScheduler
+#    minimumTimeUntilFirstEvent: 1200 # 20 mins
+#    minMaxEventTiming:
+#      min: 600 # 10 mins
+#      max: 1800 # 30 mins
+#    scheduledGameRules: !type:NestedSelector
+#      tableId: UnknownShuttlesFriendlyTable
 
 # variation passes
 - type: entity

--- a/Resources/Prototypes/_DV/CosmicCult/game_presets.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/game_presets.yml
@@ -10,7 +10,7 @@
     - CosmicCult
     - SubGamemodesRule
     #- MeteorSwarmScheduler - Goob Edit
-    - SpaceTrafficControlEventScheduler
+    #- SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - BasicStationEventScheduler
 
@@ -25,6 +25,6 @@
     - CosmicCult
     - SubGamemodesRule
     #- MeteorSwarmScheduler - Goob Edit
-    - SpaceTrafficControlEventScheduler
+    #- SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
     - BasicStationEventScheduler

--- a/Resources/Prototypes/_DV/CosmicCult/game_presets.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/game_presets.yml
@@ -25,6 +25,6 @@
     - CosmicCult
     - SubGamemodesRule
     #- MeteorSwarmScheduler - Goob Edit
-    #- SpaceTrafficControlEventScheduler
+    #- SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - BasicStationEventScheduler

--- a/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/secretplus.yml
@@ -8,8 +8,8 @@
   id: SecretPlusTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-      - !type:NestedSelector
-        tableId: SpaceTrafficControlTable
+      #- !type:NestedSelector  - Ratbite currently has no shuttle events
+      #  tableId: SpaceTrafficControlTable
       - !type:NestedSelector
         tableId: BasicGameRulesTable
 

--- a/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
+++ b/Resources/Prototypes/_Goobstation/Wizard/gamerules_wizard.yml
@@ -183,7 +183,7 @@
     - Wizard
     - SleepersOnWizardDeath
     - BasicStationEventScheduler
-    - SpaceTrafficControlEventScheduler
+    #- SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - SubGamemodesRule
     - LavalandStormScheduler # Lavaland Change

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -155,7 +155,7 @@
     - SubGamemodesRule
     - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-    - SpaceTrafficControlEventScheduler
+  #  - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - LavalandStormScheduler
 
@@ -173,7 +173,7 @@
     - LavalandStormScheduler
     - SubGamemodesRule
     - RareIonStormScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
+    # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
 
 - type: gamePreset
   id: TheGuide
@@ -189,7 +189,7 @@
     - LavalandStormScheduler
     - SubGamemodesRule
     - IonStormScheduler
-    - SpaceTrafficControlEventScheduler
+    # - SpaceTrafficControlEventScheduler
 
 - type: gamePreset
   id: SecretPlusLow

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -189,7 +189,7 @@
     - LavalandStormScheduler
     - SubGamemodesRule
     - IonStormScheduler
-    # - SpaceTrafficControlEventScheduler
+    # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
 
 - type: gamePreset
   id: SecretPlusLow

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -82,7 +82,7 @@
   rules:
 #    - KesslerSyndromeScheduler
     - RampingStationEventScheduler
-#    - SpaceTrafficControlEventScheduler
+#    - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -106,7 +106,7 @@
     - Wizard
     - RampingStationEventScheduler
     - Changeling # Goobstation - changeling playtest
-#    - SpaceTrafficControlEventScheduler
+#    - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -135,7 +135,7 @@
 #    - MeteorSwarmMildScheduler # Goob Edit
 #    - MeteorSwarmScheduler # Goob edit
     - RampingStationEventScheduler
-#    - SpaceTrafficControlEventScheduler
+#    - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - Changeling # Goobstation - changeling playtest
@@ -152,7 +152,7 @@
   rules:
   - BasicStationEventScheduler
   # - MeteorSwarmScheduler Goobstation - nuh uh
-  # - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -192,7 +192,7 @@
   rules:
     - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-  #  - SpaceTrafficControlEventScheduler
+  #  - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -233,7 +233,7 @@
   - SubGamemodesRule
   - BasicStationEventScheduler
   #- MeteorSwarmScheduler Goobstation - nuh uh
-  # - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -263,7 +263,7 @@
   - SubGamemodesRule
   - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-  # - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -282,7 +282,7 @@
   - SubGamemodesRule
   - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-  # - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -301,7 +301,7 @@
   - Zombie
   - BasicStationEventScheduler
 #  - MeteorSwarmScheduler Goobstation - nuh uh
-#  - SpaceTrafficControlEventScheduler
+#  - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -318,6 +318,6 @@
   - Zombie
   - BasicStationEventScheduler
  # - KesslerSyndromeScheduler
- # - SpaceTrafficControlEventScheduler
+ # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -65,8 +65,8 @@
   rules:
     # - MeteorSwarmScheduler Goobstation - nuh uh
     - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
+    # - SpaceTrafficControlEventScheduler - Ratbite currently has no shuttle events
+    # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -82,7 +82,7 @@
   rules:
 #    - KesslerSyndromeScheduler
     - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
+#    - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -106,7 +106,7 @@
     - Wizard
     - RampingStationEventScheduler
     - Changeling # Goobstation - changeling playtest
-    - SpaceTrafficControlEventScheduler
+#    - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -135,8 +135,8 @@
 #    - MeteorSwarmMildScheduler # Goob Edit
 #    - MeteorSwarmScheduler # Goob edit
     - RampingStationEventScheduler
-    - SpaceTrafficControlEventScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
+#    - SpaceTrafficControlEventScheduler
+    # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
     - BasicRoundstartVariation
     - Changeling # Goobstation - changeling playtest
     - LavalandStormScheduler # Lavaland Change
@@ -152,7 +152,7 @@
   rules:
   - BasicStationEventScheduler
   # - MeteorSwarmScheduler Goobstation - nuh uh
-  - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -165,7 +165,7 @@
   showInVote: false #4boring4vote
   description: greenshift-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler
+  # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -192,7 +192,7 @@
   rules:
     - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-    - SpaceTrafficControlEventScheduler
+  #  - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
     - LavalandStormScheduler # Lavaland Change
 
@@ -204,7 +204,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler
+  # - SpaceTrafficControlFriendlyEventScheduler - Ratbite currently has no shuttle events
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -233,7 +233,7 @@
   - SubGamemodesRule
   - BasicStationEventScheduler
   #- MeteorSwarmScheduler Goobstation - nuh uh
-  - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -263,7 +263,7 @@
   - SubGamemodesRule
   - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-  - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -277,12 +277,12 @@
   description: rev-description
   showInVote: false
   rules:
-  - DummyNonAntagChance  
+  - DummyNonAntagChance
   - Revolutionary
   - SubGamemodesRule
   - BasicStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
-  - SpaceTrafficControlEventScheduler
+  # - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -301,7 +301,7 @@
   - Zombie
   - BasicStationEventScheduler
 #  - MeteorSwarmScheduler Goobstation - nuh uh
-  - SpaceTrafficControlEventScheduler
+#  - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change
 
@@ -318,6 +318,6 @@
   - Zombie
   - BasicStationEventScheduler
  # - KesslerSyndromeScheduler
-  - SpaceTrafficControlEventScheduler
+ # - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - LavalandStormScheduler # Lavaland Change

--- a/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
+++ b/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
@@ -2,7 +2,7 @@ light_mode unshaded;
 
 uniform highp float hue;
 uniform highp float textureHeight;
-uniform highp float pixel_scale = 12.0;
+uniform highp float pixel_scale;
 
 //
 // Description : Array and textureless GLSL 2D/3D/4D simplex


### PR DESCRIPTION
Removes a value initializer from the shader Holographic.swsl, as compatibility mode rendering does not support initializers like this.
Fixes the client crashing when compatibility mode is enabled, which also means people who need compatibility mode can play.