### PR TITLE
Compatibility Mode Crash Fix

### DIFF
--- a/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
+++ b/Resources/Textures/Nyanotrasen/Shaders/holographic.swsl
@@ -2,7 +2,7 @@ light_mode unshaded;
 
 uniform highp float hue;
 uniform highp float textureHeight;
-uniform highp float pixel_scale = 12.0;
+uniform highp float pixel_scale;
 
 //
 // Description : Array and textureless GLSL 2D/3D/4D simplex


### PR DESCRIPTION
Removes a value initializer from the shader Holographic.swsl, as compatibility mode rendering does not support initializers like this.
Fixes the client crashing when compatibility mode is enabled, which also means people who need compatibility mode can play.