### PR TITLE
Added the Throngler Model2

### DIFF
--- a/Content.Server/_Lavaland/Pressure/PressureDamageChangeComponent.cs
+++ b/Content.Server/_Lavaland/Pressure/PressureDamageChangeComponent.cs
@@ -31,7 +31,7 @@ public sealed partial class PressureDamageChangeComponent : Component
     public bool Enabled = true;
 
     [DataField]
-    public float LowerBound = Atmospherics.OneAtmosphere * 0.2f;
+    public float LowerBound = Atmospherics.OneAtmosphere * 0.0f;
 
     [DataField]
     public float UpperBound = Atmospherics.OneAtmosphere * 0.5f;

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -113,5 +113,7 @@
     cost: 3000
   - id: ShelterCapsuleLuxury
     cost: 3000
+  - id: thronglerRatbite
+    cost: 3500
   # TODO: luxury elite bar capsule for 10k
   # TODO: mining drone stuff

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -386,3 +386,46 @@
         params:
           variation: 0.250
           volume: -2
+
+- type: entity
+  name: throngler Model2
+  parent: [ BaseSword, BaseCargoContraband ]
+  id: thronglerRatbite
+  description: Nanotrasen finally found a way to not make this thing a nightmare for everyone. At least it still works
+  components:
+    - type: Sprite
+      sprite: Objects/Weapons/Melee/Throngler2.rsi
+    - type: MeleeWeapon
+      attackRate: 10
+      autoAttack: true
+      damage:
+        types:
+          Structural: 150
+          Slash: 20 #Horror
+          Blunt: 20
+          Heat: 20
+          Piercing: 20
+          Radiation: 10
+      soundHit:
+        path: /Audio/Effects/explosion_small1.ogg
+    - type: Reflect # Goob edit
+      reflectProb: .5
+      reflects:
+        - Energy
+      spread: 90
+    - type: Item
+      size: Large
+      sprite: Objects/Weapons/Melee/Throngler-in-hand.rsi
+    - type: DisarmMalus
+    - type: Grammar
+      attributes:
+        proper: true
+    - type: ThrowableBlocker # Goobstation
+      blockSound:
+        path: /Audio/Weapons/eblade1.ogg
+        params:
+          variation: 0.250
+          volume: -2
+    - type: PressureDamageChange
+      appliedModifier: 0.01
+


### PR DESCRIPTION
Added the Throngler Model2. Fits in a bag, is full auto but has a massive 0.01% damage modifier in atmosphere. So you cant just go around and murder the entire station. Added to the salvage vendor for 3500 points, making it a powerful but lategame salvage weapon
Tweaked the lower bound from the PressureDamageChangeComponent to allow salvager weapons to be used in space on salvage magnet generated wrecks with the intention of making wrecks more interesting to do and add an alternative gameplay loop to the salvager job

Huge thanks to [iNV3RT3D](https://github.com/iNV3RT3D) for helping with the component explanation

**Changelog**
:cl:
- add: Added the Throngler Model2 (Id: ThronglerRatbite)
- add: Added the Throngler Model2 to the Salvage Vendor for 3500 points
- tweak: Tweaked LowerBound for PressureDamageChangeComponent to be default 0.0f from 0.2f