### PR TITLE
Blobmidround spam found dead in a ditch

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -205,9 +205,9 @@
     duration: null
     maxOccurrences: 2
     chaos:
-      Hostile: 300
-      Medical: 300
-      Death: 300
+      Hostile: 600 #Ratbites, Secret+ keeps calling blob in which ends rounds instantly without admin intervention
+      Medical: 600 #Ratbites, Secret+ keeps calling blob in which ends rounds instantly without admin intervention
+      Death: 600 #Ratbites, Secret+ keeps calling blob in which ends rounds instantly without admin intervention
     eventType: HostilesSpawn
   - type: GameRule
     chaosScore: 800

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -210,7 +210,7 @@
       Death: 600 #Ratbites, Secret+ keeps calling blob in which ends rounds instantly without admin intervention
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 800
+    chaosScore: 1600 #Ratbites, doubling the score to keep secret+ at bay once it fires it
   - type: BlobSpawnRule
     carrierBlobProtos:
     - SpawnPointGhostBlobRat


### PR DESCRIPTION
Increases chaos score so that secret+ doesnt fucking dare spawn it in unless chaos is up (round has been going on for too long)
This is one of many changes that I'm going to PR based around Secret+ and Survival because for some reason they spam shit.