### PR TITLE
Secretplus found shot dead

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/gamedirector_weights.yml
@@ -20,9 +20,9 @@
     Changeling: 0.10
     Nukeops: 0.05
     Revolutionary: 0.05
-    Zombie: 0.04
+    Zombie: 0.06 #Ratbites
     Heretic: 0.11
-    BlobGameMode: 0.05
+    BlobGameMode: 0.03 #Ratbites
     Wizard: 0.025
     CosmicCult: 0.05 # make it semi often so we can test it
     #HonkOps: 0.01 # this test fail was real holy shit it was only a preset the entire a time i was lied too by myself
@@ -52,12 +52,15 @@
   id: Wizard
   modes:
   - Wizard
+  - Heretic #Ratbites, one magic threat at a time.
+  - CosmicCult #Ratbites, one magic threat at a time.
 
 - type: incompatibleModes
   id: Heretic
   modes:
   - Heretic
   - CosmicCult
+  - Wizard #Ratbites, one magic threat at a time.
 
 - type: incompatibleModes
   id: BlobGameMode
@@ -73,6 +76,7 @@
   - Nukeops
   - CosmicCult
   - HonkOps
+  - BlobGameMode #Ratbites
 
 - type: incompatibleModes
   id: Revolutionary
@@ -80,6 +84,7 @@
   - Nukeops
   - CosmicCult
   - HonkOps
+  - BlobGameMode #Ratbites, can mess with gameflow.
 
 - type: incompatibleModes
   id: CosmicCult

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -200,8 +200,8 @@
   components:
   - type: StationEvent
     weight: 2
-    earliestStart: 75
-    minimumPlayers: 30 # how is that 20 people when rat king is 30??? changed.
+    earliestStart: 75 #Constantly fucking violated by weird gamemodes kek
+    minimumPlayers: 40 #Ratbites, realisticly blob is balanced for 40+
     duration: null
     maxOccurrences: 2
     chaos:

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -175,7 +175,7 @@
   name: sleeper-title
   description: sleeper-description
   showInVote: true
-  minPlayers: 5
+  minPlayers: 3 # Ratbites, lowering pop needed.
   rules:
     - PermaBrig # RatBite - Multi-Round brig system
     - CalmDynamic
@@ -191,8 +191,8 @@
     - combatdynamic
   name: guide-title
   description: guide-description
-  showInVote: false
-  minPlayers: 25
+  showInVote: true # Ratbites, Reintroducing Gamedirector as its more stable than secret+
+  minPlayers: 18 # Ratbites, lowering pop needed.
   rules:
     - PermaBrig # RatBite - Multi-Round brig system
     - CombatDynamic
@@ -209,7 +209,7 @@
     - turbulence
   name: secretplus-low-title
   description: secretplus-low-description
-  showInVote: true
+  showInVote: false #Ratbites, Secretplus violates gamerules and is impossible to track, fuck ts shit...
   rules:
     - PermaBrig # RatBite - Multi-Round brig system
     - SecretPlusLow
@@ -223,7 +223,7 @@
     - entropy
   name: secretplus-mid-title
   description: secretplus-mid-description
-  showInVote: true
+  showInVote: false #Ratbites
   rules:
     - PermaBrig # RatBite - Multi-Round brig system
     - SecretPlusMid
@@ -238,7 +238,7 @@
     - chaos
   name: secretplus-admeme-title
   description: secretplus-admeme-description
-  showInVote: false # 1984
+  showInVote: false # Meds.
   rules:
     - SecretPlusAdmeme
     - LavalandStormScheduler
@@ -251,7 +251,7 @@
     - survivalnew
   name: survivalplus-title
   description: survivalplus-description
-  showInVote: true
+  showInVote: true #Keep it for now, but may also be butched.
   rules:
     - PermaBrig # RatBite - Multi-Round brig system
     - SecretPlusRampingMid

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -151,7 +151,7 @@
   - extended
   - shittersafari
   name: extended-title
-  showInVote: false #2boring2vote
+  showInVote: true #Ratbites, easier to control survival.
   description: extended-description
   rules:
   - PermaBrig # RatBite - Multi-Round brig system
@@ -167,7 +167,7 @@
   - greenshift
   - shittersafarideluxeedition
   name: greenshift-title
-  showInVote: false #4boring4vote
+  showInVote: true #If the masses want a greenshift there is a reason.
   description: greenshift-description
   rules:
   - PermaBrig # RatBite - Multi-Round brig system
@@ -255,7 +255,7 @@
   name: death-match-title
   description: death-match-description
   maxPlayers: 15
-  showInVote: true
+  showInVote: false #Ratbites, never voted for (should be reworked maybe or just moved as an admeme mode.)
   supportedMaps: DeathMatchMapPool
   rules:
     - DeathMatch31


### PR DESCRIPTION
Disables secretplus
Enables The Guide
Lowers required pop for The Ghost and The Guide
Tweaks gamedirector weights.
Stops multiple magic threats from showing up at once durring The Ghost and The Guide (Magic threats being cosmic cult, heretics and wizards.)
Stops midroundblob being called below 40pop (If it follows standard calls)
Enables Extended and Greenshift to be voted for, if people vote for these theres a good reason to it.