### PR TITLE
Engineering Declawing - Power

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -164,10 +164,10 @@ public sealed class AmeNodeGroup : BaseNodeGroup
 
         // Ratbite - Modified to make over safe limit injections also provide diminishing returns
         // While everything within the safe limit produces the usual amount, anything over will produce less and less than the normal
-        var safeLimit = CoreCount * 2; # Ratbite - Start
+        var safeLimit = CoreCount * 2; // Ratbite - Start
         var overLimit = MathF.Max(fuel - safeLimit, 0);
 
-        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0); # Ratbite - End
+        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0); // Ratbite - End
     }
 
     public int GetTotalStability()

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -135,16 +135,44 @@ public sealed class AmeNodeGroup : BaseNodeGroup
     {
         overloading = false;
 
+        var shieldQuery = _entMan.GetEntityQuery<AmeShieldComponent>();
         if (fuel <= 0 || CoreCount <= 0)
             return 0;
 
         var safeFuelLimit = CoreCount * 2;
 
         var powerOutput = CalculatePower(fuel, CoreCount);
-        if (fuel >= safeFuelLimit)
-            overloading = true;
+        if (fuel <= safeFuelLimit)
+            return powerOutput;
 
-        //Ratbite - Removed explosion and stability logic, to easy to sabo. Check CalculatePower() below for our alternative
+        // The AME is being overloaded.
+        // Note about these maths: I would assume the general idea here is to make larger engines less safe to overload.
+        // In other words, yes, those are supposed to be CoreCount, not safeFuelLimit.
+        var overloadVsSizeResult = fuel - CoreCount;
+
+        var instability = overloadVsSizeResult / CoreCount;
+        var fuzz = _random.Next(-1, 2); // -1 to 1
+        instability += fuzz; // fuzz the values a tiny bit.
+
+        overloading = true;
+        var integrityCheck = 100;
+        foreach (var coreUid in _cores)
+        {
+            if (!shieldQuery.TryGetComponent(coreUid, out var core))
+                continue;
+
+            var oldIntegrity = core.CoreIntegrity;
+            core.CoreIntegrity -= instability;
+
+            if (oldIntegrity > 95
+                && core.CoreIntegrity <= 95
+                && core.CoreIntegrity < integrityCheck)
+                integrityCheck = core.CoreIntegrity;
+        }
+
+        // Admin alert
+        if (integrityCheck != 100 && _masterController.HasValue)
+            _chat.SendAdminAlert($"AME overloading: {_entMan.ToPrettyString(_masterController.Value)}");
 
         return powerOutput;
     }
@@ -157,17 +185,11 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Balanced around a single core AME with injection level 2 producing 120KW.
         // Two core with four injection is 150kW. Two core with two injection is 90kW.
 
-        // Increasing core count creates diminishing returns, increasing injection amount increases
+        // Increasing core count creates diminishing returns, increasing injection amount increases 
         // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
-
-        // Ratbite - Modified to make over safe limit injections also provide diminishing returns
-        // While everything within the safe limit produces the usual amount, anything over will produce less and less than the normal
-        var safeLimit = CoreCount * 2; // Ratbite - Start
-        var overLimit = MathF.Max(fuel - safeLimit, 0);
-
-        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0); // Ratbite - End
+        return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0);
     }
 
     public int GetTotalStability()

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -135,13 +135,19 @@ public sealed class AmeNodeGroup : BaseNodeGroup
     {
         overloading = false;
 
-        var shieldQuery = _entMan.GetEntityQuery<AmeShieldComponent>();
+        // var shieldQuery = _entMan.GetEntityQuery<AmeShieldComponent>(); Ratbite - Remove explosion code
         if (fuel <= 0 || CoreCount <= 0)
             return 0;
 
         var safeFuelLimit = CoreCount * 2;
 
         var powerOutput = CalculatePower(fuel, CoreCount);
+        if (fuel >= safeFuelLimit)
+            overloading = true;
+
+        return powerOutput;
+
+        /* Ratbite - Removed explosion and stability logic, to easy to sabo. Check CalculatePower() below for our alternative.
         if (fuel <= safeFuelLimit)
             return powerOutput;
 
@@ -164,17 +170,8 @@ public sealed class AmeNodeGroup : BaseNodeGroup
             var oldIntegrity = core.CoreIntegrity;
             core.CoreIntegrity -= instability;
 
-            if (oldIntegrity > 95
-                && core.CoreIntegrity <= 95
-                && core.CoreIntegrity < integrityCheck)
-                integrityCheck = core.CoreIntegrity;
-        }
-
-        // Admin alert
-        if (integrityCheck != 100 && _masterController.HasValue)
-            _chat.SendAdminAlert($"AME overloading: {_entMan.ToPrettyString(_masterController.Value)}");
-
         return powerOutput;
+        */
     }
 
     /// <summary>
@@ -185,11 +182,17 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Balanced around a single core AME with injection level 2 producing 120KW.
         // Two core with four injection is 150kW. Two core with two injection is 90kW.
 
-        // Increasing core count creates diminishing returns, increasing injection amount increases 
+        // Increasing core count creates diminishing returns, increasing injection amount increases
         // Unlike the previous solution, increasing fuel and cores always leads to an increase in power, even if by very small amounts.
         // Increasing core count without increasing fuel always leads to reduced power as well.
         // At 18+ cores and 2 inject, the power produced is less than 0, the Max ensures the AME can never produce "negative" power.
-        return MathF.Max(200000f * MathF.Log10(2 * fuel * MathF.Pow(cores, (float)-0.5)), 0);
+
+        // Ratbite - Modified to make over safe limit injections also provide diminishing returns
+        // While everything within the safe limit produces the usual amount, anything over will produce less and less than the normal
+        var safeLimit = CoreCount * 2; // Ratbite - Start
+        var overLimit = MathF.Max(fuel - safeLimit, 0);
+
+        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0); // Ratbite - End
     }
 
     public int GetTotalStability()

--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -164,10 +164,10 @@ public sealed class AmeNodeGroup : BaseNodeGroup
 
         // Ratbite - Modified to make over safe limit injections also provide diminishing returns
         // While everything within the safe limit produces the usual amount, anything over will produce less and less than the normal
-        var safeLimit = CoreCount * 2;
+        var safeLimit = CoreCount * 2; # Ratbite - Start
         var overLimit = MathF.Max(fuel - safeLimit, 0);
 
-        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0);
+        return MathF.Max(200000f * MathF.Log10(2 * ( MathF.Min(fuel, safeLimit) + MathF.Pow(overLimit+0.00001f, -0.4f)*overLimit ) * MathF.Pow(cores, (float)-0.5)), 0); # Ratbite - End
     }
 
     public int GetTotalStability()

--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -166,8 +166,8 @@ public sealed class AmeControllerSystem : EntitySystem
         group.UpdateCoreVisuals();
         UpdateDisplay(uid, controller.Stability, controller);
 
-        //if (controller.Stability <= 0)   Ratbite - Disabled explosive AME, too easy to sabotage
-        //    group.ExplodeCores();                  Instead, made overcharging have diminishing returns
+        if (controller.Stability <= 0)
+            group.ExplodeCores();
     }
 
     public void UpdateUi(EntityUid uid, AmeControllerComponent? controller = null)

--- a/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
+++ b/Content.Server/Ame/EntitySystems/AmeControllerSystem.cs
@@ -166,8 +166,8 @@ public sealed class AmeControllerSystem : EntitySystem
         group.UpdateCoreVisuals();
         UpdateDisplay(uid, controller.Stability, controller);
 
-        if (controller.Stability <= 0)
-            group.ExplodeCores();
+        //if (controller.Stability <= 0)   Ratbite - Disabled explosive AME, too easy to sabotage
+        //    group.ExplodeCores();                  Instead, made overcharging have diminishing returns
     }
 
     public void UpdateUi(EntityUid uid, AmeControllerComponent? controller = null)

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -500,12 +500,12 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     private void ChangePowerVisualizer(int power, Entity<ContainmentFieldGeneratorComponent> generator)
     {
         var component = generator.Comp;
-        var visual = PowerLevelVisuals.NoPower;
+        var visual = PowerLevelVisuals.NoPower; //Ratbite - Start
         if (component.PowerBuffer > component.PowerMinimum)
             visual = PowerLevelVisuals.MediumPower;
         if (component.PowerBuffer == component.PowerMaximum)
             visual = PowerLevelVisuals.HighPower;
-        _visualizer.SetData(generator, ContainmentFieldGeneratorVisuals.PowerLight, visual);
+        _visualizer.SetData(generator, ContainmentFieldGeneratorVisuals.PowerLight, visual); //Ratbite - End
     }
 
     /// <summary>

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -500,14 +500,12 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     private void ChangePowerVisualizer(int power, Entity<ContainmentFieldGeneratorComponent> generator)
     {
         var component = generator.Comp;
-        _visualizer.SetData(generator, ContainmentFieldGeneratorVisuals.PowerLight, component.PowerBuffer switch
-        {
-            <= 0 => PowerLevelVisuals.NoPower,
-            >= 25 => PowerLevelVisuals.HighPower,
-            _ => (component.PowerBuffer < component.PowerMinimum)
-                ? PowerLevelVisuals.LowPower
-                : PowerLevelVisuals.MediumPower
-        });
+        var visual = PowerLevelVisuals.NoPower;
+        if (component.PowerBuffer > component.PowerMinimum)
+            visual = PowerLevelVisuals.MediumPower;
+        if (component.PowerBuffer == component.PowerMaximum)
+            visual = PowerLevelVisuals.HighPower;
+        _visualizer.SetData(generator, ContainmentFieldGeneratorVisuals.PowerLight, visual);
     }
 
     /// <summary>

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -338,8 +338,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
             RemoveConnections(generator);
         }
 
-        var chargeEvent = new GeneratorChargeChangedEvent(generator, generator); # Ratbite
-        RaiseLocalEvent(generator, ref chargeEvent, broadcast: true); # Ratbite
+        var chargeEvent = new GeneratorChargeChangedEvent(generator, generator); // Ratbite
+        RaiseLocalEvent(generator, ref chargeEvent, broadcast: true); // Ratbite
 
         ChangePowerVisualizer(power, generator);
     }
@@ -448,12 +448,12 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
                 fieldXForm.LocalRotation = rotatedAngle;
             }
 
-            if (TryComp<ContainmentFieldComponent>(newField, out var comp)) # Ratbite - Start
+            if (TryComp<ContainmentFieldComponent>(newField, out var comp)) // Ratbite - Start
             {
                 comp.BoundGenerators = new List<Entity<ContainmentFieldGeneratorComponent>>();
                 comp.BoundGenerators.Add(firstGen);
                 comp.BoundGenerators.Add(secondGen);
-            } # Ratbite - End
+            } // Ratbite - End
 
             fieldList.Add(newField);
             currentOffset += dirVec;

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -104,6 +104,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Administration.Logs;
+using Content.Server.Chat.Systems;
 using Content.Server.Popups;
 using Content.Server.Singularity.Events;
 using Content.Shared.Construction.Components;
@@ -130,6 +131,7 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
     [Dependency] private readonly SharedPointLightSystem _light = default!;
     [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
     [Dependency] private readonly TagSystem _tags = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
 
     public override void Initialize()
     {
@@ -336,6 +338,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
             RemoveConnections(generator);
         }
 
+
+
         ChangePowerVisualizer(power, generator);
     }
 
@@ -441,6 +445,13 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
                 var rotatedAngle = Angle.FromDegrees(rotateBy90);
 
                 fieldXForm.LocalRotation = rotatedAngle;
+            }
+
+            if (TryComp<ContainmentFieldComponent>(newField, out var comp))
+            {
+                comp.BoundGenerators = new List<Entity<ContainmentFieldGeneratorComponent>>();
+                comp.BoundGenerators.Add(firstGen);
+                comp.BoundGenerators.Add(secondGen);
             }
 
             fieldList.Add(newField);

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -113,6 +113,7 @@ using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Singularity.Components;
 using Content.Shared.Tag;
+using Content.Shared.Weapons.Melee.Events; //Ratbite
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
@@ -143,6 +144,7 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
         SubscribeLocalEvent<ContainmentFieldGeneratorComponent, ComponentRemove>(OnComponentRemoved);
         SubscribeLocalEvent<ContainmentFieldGeneratorComponent, EventHorizonAttemptConsumeEntityEvent>(PreventBreach);
         SubscribeLocalEvent<ContainmentFieldGeneratorComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ContainmentFieldGeneratorComponent, AttackedEvent>(OnMeleeHit); //Ratbite - Generate on melee hit
     }
 
     public override void Update(float frameTime)
@@ -184,6 +186,12 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
             ReceivePower(generator.Comp.PowerReceived, generator);
             generator.Comp.Accumulator = 0f;
         }
+    }
+
+    private void OnMeleeHit(Entity<ContainmentFieldGeneratorComponent> generator, ref AttackedEvent args) //Ratbite, generate charge on melee hit
+    {
+        ReceivePower(generator.Comp.PunchPowerReceived, generator);
+        generator.Comp.Accumulator = 0f;
     }
 
     private void OnExamine(EntityUid uid, ContainmentFieldGeneratorComponent component, ExaminedEvent args)

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -338,8 +338,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
             RemoveConnections(generator);
         }
 
-        var chargeEvent = new GeneratorChargeChangedEvent(generator, generator);
-        RaiseLocalEvent(generator, ref chargeEvent, broadcast: true);
+        var chargeEvent = new GeneratorChargeChangedEvent(generator, generator); # Ratbite
+        RaiseLocalEvent(generator, ref chargeEvent, broadcast: true); # Ratbite
 
         ChangePowerVisualizer(power, generator);
     }

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -338,7 +338,8 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
             RemoveConnections(generator);
         }
 
-
+        var chargeEvent = new GeneratorChargeChangedEvent(generator, generator);
+        RaiseLocalEvent(generator, ref chargeEvent, broadcast: true);
 
         ChangePowerVisualizer(power, generator);
     }

--- a/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/ContainmentFieldGeneratorSystem.cs
@@ -448,12 +448,12 @@ public sealed class ContainmentFieldGeneratorSystem : EntitySystem
                 fieldXForm.LocalRotation = rotatedAngle;
             }
 
-            if (TryComp<ContainmentFieldComponent>(newField, out var comp))
+            if (TryComp<ContainmentFieldComponent>(newField, out var comp)) # Ratbite - Start
             {
                 comp.BoundGenerators = new List<Entity<ContainmentFieldGeneratorComponent>>();
                 comp.BoundGenerators.Add(firstGen);
                 comp.BoundGenerators.Add(secondGen);
-            }
+            } # Ratbite - End
 
             fieldList.Add(newField);
             currentOffset += dirVec;

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -67,6 +67,7 @@ using Content.Shared.Database;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Lock;
 using Content.Shared.Popups;
@@ -161,8 +162,15 @@ namespace Content.Server.Singularity.EntitySystems
                         component.NextWarning = _timing.CurTime + component.WarningCooldown;
                         foreach (var channel in component.WarningChannels)
                         {
+                            var title = "no ID found";
+                            var getIdentityEvent = new TryGetIdentityShortInfoEvent(uid, args.User);
+                            RaiseLocalEvent(getIdentityEvent);
+                            if(getIdentityEvent.Title != null)
+                                title = getIdentityEvent.Title;
+
                             _radio.SendRadioMessage(uid,
-                                Loc.GetString("containment-field-emitter-powering-off"),
+                                Loc.GetString("containment-field-emitter-powering-off",
+                                    ("id", title)),
                                 channel,
                                 uid,
                                 escapeMarkup: false);

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -190,7 +190,7 @@ namespace Content.Server.Singularity.EntitySystems
             }
         }
 
-        private void OnPowerOff(EntityUid uid, EmitterComponent component, PowerOffDoAfterEvent args) # Ratbite - Start
+        private void OnPowerOff(EntityUid uid, EmitterComponent component, PowerOffDoAfterEvent args) //Ratbite - Start
         {
             if (args.Cancelled)
                 return;
@@ -198,7 +198,7 @@ namespace Content.Server.Singularity.EntitySystems
             SwitchOff(uid, component);
             _popup.PopupEntity(Loc.GetString("comp-emitter-turned-off",
                 ("target", uid)), uid, args.User);
-        } # Ratbite  - End
+        } //Ratbite  - End
 
         private void OnGetVerb(EntityUid uid, EmitterComponent component, GetVerbsEvent<Verb> args)
         {

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -162,7 +162,7 @@ namespace Content.Server.Singularity.EntitySystems
                         component.NextWarning = _timing.CurTime + component.WarningCooldown;
                         foreach (var channel in component.WarningChannels)
                         {
-                            var title = "no ID found";
+                            var title = Loc.GetString("containment-field-emitter-no-id-found");
                             var getIdentityEvent = new TryGetIdentityShortInfoEvent(uid, args.User);
                             RaiseLocalEvent(getIdentityEvent);
                             if(getIdentityEvent.Title != null)

--- a/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EmitterSystem.cs
@@ -190,7 +190,7 @@ namespace Content.Server.Singularity.EntitySystems
             }
         }
 
-        private void OnPowerOff(EntityUid uid, EmitterComponent component, PowerOffDoAfterEvent args)
+        private void OnPowerOff(EntityUid uid, EmitterComponent component, PowerOffDoAfterEvent args) # Ratbite - Start
         {
             if (args.Cancelled)
                 return;
@@ -198,7 +198,7 @@ namespace Content.Server.Singularity.EntitySystems
             SwitchOff(uid, component);
             _popup.PopupEntity(Loc.GetString("comp-emitter-turned-off",
                 ("target", uid)), uid, args.User);
-        }
+        } # Ratbite  - End
 
         private void OnGetVerb(EntityUid uid, EmitterComponent component, GetVerbsEvent<Verb> args)
         {

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -299,39 +299,52 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
 
         string? message = null;
 
-        if (newpercent <= 0f)
+        switch (newpercent)
         {
-            if (oldpercent > 0f)
+            case <= 0f:
             {
-                message = Loc.GetString("containment-field-buffer-drop-loose", ("buffer", displayPercent));
+                if (oldpercent > 0f) //These checks make sure that we passed the threshold THIS buffer update
+                {
+                    message = Loc.GetString("containment-field-buffer-drop-loose", ("buffer", displayPercent));
+                }
+
+                break;
             }
-        }
-        if (newpercent <= 0.10f)
-        {
-            if (oldpercent > 0.10f)
+            case <= 0.10f:
             {
-                message = Loc.GetString("containment-field-buffer-drop-emergency", ("buffer", displayPercent));
+                if (oldpercent > 0.10f)
+                {
+                    message = Loc.GetString("containment-field-buffer-drop-emergency", ("buffer", displayPercent));
+                }
+
+                break;
             }
-        }
-        else if (newpercent <= 0.25f)
-        {
-            if (oldpercent > 0.25f)
+            case <= 0.25f:
             {
-                message = Loc.GetString("containment-field-buffer-drop-emergency", ("buffer", displayPercent));
+                if (oldpercent > 0.25f)
+                {
+                    message = Loc.GetString("containment-field-buffer-drop-emergency", ("buffer", displayPercent));
+                }
+
+                break;
             }
-        }
-        else if (newpercent <= 0.50f)
-        {
-            if (oldpercent > 0.50f)
+            case <= 0.50f:
             {
-                message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
+                if (oldpercent > 0.50f)
+                {
+                    message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
+                }
+
+                break;
             }
-        }
-        else if (newpercent <= 0.80f)
-        {
-            if (oldpercent > 0.80f)
+            case <= 0.80f:
             {
-                message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
+                if (oldpercent > 0.80f)
+                {
+                    message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
+                }
+
+                break;
             }
         }
 

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -259,15 +259,15 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
     {
         if (!CanConsumeEntity(hungry, morsel, eventHorizon))
         {
-            if (TryComp<ContainmentFieldComponent>(morsel, out var field))
+            if (TryComp<ContainmentFieldComponent>(morsel, out var field)) //Ratbite - Start
             {
                 foreach (var gen in field.BoundGenerators)
                 {
-                    if (eventHorizon.ContainingFieldGenerators.Add(gen))
+                    eventHorizon.ContainingFieldGenerators.Add(gen);
                 }
             }
             return false;
-        }
+        } //Ratbite - End
 
         ConsumeEntity(hungry, morsel, eventHorizon, outerContainer);
         return true;
@@ -286,7 +286,6 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
             var validLowest = lowest.Value;
             if (validLowest.Comp.PowerBuffer != eventHorizon.LowestPowerGenBuffer)
             {
-                Log.Info("Lowest buffer: "+validLowest.Comp.PowerBuffer);
                 UpdateBuffer(eventHorizon, validLowest);
             }
         }
@@ -298,8 +297,6 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         var oldpercent = (eventHorizon.LowestPowerGenBuffer - gen.Comp.PowerMinimum) / (float)(gen.Comp.PowerMaximum - gen.Comp.PowerMinimum);
 
         var displayPercent = MathF.Round(newpercent * 100f);
-
-        Log.Info("Updating buffer: "+newpercent+" "+oldpercent);
 
         string? message = null;
 

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -295,8 +295,8 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
 
     private void UpdateBuffer(EventHorizonComponent eventHorizon, Entity<ContainmentFieldGeneratorComponent> gen)
     {
-        var newpercent = (gen.Comp.PowerBuffer - gen.Comp.PowerMinimum) / 21f;
-        var oldpercent = (eventHorizon.LowestPowerGenBuffer - gen.Comp.PowerMinimum) / 21f;
+        var newpercent = (gen.Comp.PowerBuffer - gen.Comp.PowerMinimum) / (float)(gen.Comp.PowerMaximum - gen.Comp.PowerMinimum);
+        var oldpercent = (eventHorizon.LowestPowerGenBuffer - gen.Comp.PowerMinimum) / (float)(gen.Comp.PowerMaximum - gen.Comp.PowerMinimum);
 
         var displayPercent = MathF.Round(newpercent * 100f);
 
@@ -332,9 +332,9 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
                 message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
             }
         }
-        else if (newpercent <= 0.75f)
+        else if (newpercent <= 0.80f)
         {
-            if (oldpercent > 0.75f)
+            if (oldpercent > 0.80f)
             {
                 message = Loc.GetString("containment-field-buffer-drop-warning", ("buffer", displayPercent));
             }
@@ -354,8 +354,9 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
 
     private Entity<ContainmentFieldGeneratorComponent>? GetLowestPower(HashSet<Entity<ContainmentFieldGeneratorComponent>> gens)
     {
-        var low = 25;
+        var low = 5000;
         Entity<ContainmentFieldGeneratorComponent>? lowgen = null;
+        gens.RemoveWhere(g => !g.Owner.Valid);
         foreach (var gen in gens)
         {
             if (gen.Comp.PowerBuffer < low)

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -280,9 +280,8 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
         {
             var lowest = GetLowestPower(eventHorizon.ContainingFieldGenerators);
             if (lowest == null)
-            {
                 continue;
-            }
+
             var validLowest = lowest.Value;
             if (validLowest.Comp.PowerBuffer != eventHorizon.LowestPowerGenBuffer)
             {

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -340,7 +340,6 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
             }
         }
 
-        Log.Info(""+message);
         if(message != null)
             MakeAnnouncement(gen, message);
 
@@ -349,8 +348,6 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
 
     private void MakeAnnouncement(EntityUid uid, string message, string? customSender = null)
     {
-        Log.Info("Announcement sent by "+uid+" is : "+message+"");
-
         var sender = customSender != null ? customSender : Loc.GetString("containment-field-announcement");
         _chat.DispatchStationAnnouncement(uid, message, sender, colorOverride: Color.Yellow);
     }

--- a/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
+++ b/Content.Server/Singularity/EntitySystems/EventHorizonSystem.cs
@@ -264,7 +264,6 @@ public sealed class EventHorizonSystem : SharedEventHorizonSystem
                 foreach (var gen in field.BoundGenerators)
                 {
                     if (eventHorizon.ContainingFieldGenerators.Add(gen))
-                        Log.Info("New gen added to list");
                 }
             }
             return false;

--- a/Content.Server/Singularity/Events/GeneratorChargeChangedEvent.cs
+++ b/Content.Server/Singularity/Events/GeneratorChargeChangedEvent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Singularity.Components;
+
+namespace Content.Server.Singularity.Events;
+
+/// <summary>
+/// Event raised on the target entity whenever a field generator's charge changes.
+/// </summary>
+[ByRefEvent]
+public record struct GeneratorChargeChangedEvent(EntityUid entity, ContainmentFieldGeneratorComponent generator)
+{
+    /// <summary>
+    /// The generator losing charge.
+    /// </summary>
+    public readonly EntityUid Entity = entity;
+
+    /// <summary>
+    /// The event horizon consuming the target entity.
+    /// </summary>
+    public readonly ContainmentFieldGeneratorComponent Generator = generator;
+}

--- a/Content.Shared/Singularity/Components/ContainmentFieldComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldComponent.cs
@@ -110,4 +110,10 @@ public sealed partial class ContainmentFieldComponent : Component
     /// </summary>
     [DataField]
     public bool DestroyGarbage = true;
+
+    /// <summary>
+    /// What generators created us?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public List<Entity<ContainmentFieldGeneratorComponent>> BoundGenerators;
 }

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -78,7 +78,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     public int PowerBuffer
     {
         get => _powerBuffer;
-        set => _powerBuffer = Math.Clamp(value, 0, 25); //have this decrease over time if not hit by a bolt
+        set => _powerBuffer = Math.Clamp(value, 0, PowerMaximum); //have this decrease over time if not hit by a bolt
     }
 
     /// <summary>
@@ -89,6 +89,13 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     public int PowerMinimum = 3;
 
     /// <summary>
+    /// The maximum charge the field generator can store
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("powerMaximum")]
+    public int PowerMaximum = 30; //Ratbite
+
+    /// <summary>
     /// How much power should this field generator receive from a collision
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
@@ -96,11 +103,11 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     public int PowerReceived = 3;
 
     /// <summary>
-    /// Punch the generator into functionality! Ratbite code
+    /// Punch the generator into functionality!
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("punchPower")]
-    public int PunchPowerReceived = 2;
+    public int PunchPowerReceived = 2; //Ratbite
 
     /// <summary>
     /// How much power should this field generator lose if not powered?

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -92,7 +92,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// The maximum charge the field generator can store
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("powerMaximum")]
+    [DataField]
     public int PowerMaximum = 30; //Ratbite
 
     /// <summary>
@@ -106,7 +106,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// Punch the generator into functionality!
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("punchPower")]
+    [DataField]
     public int PunchPowerReceived = 2; //Ratbite
 
     /// <summary>

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -96,6 +96,13 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     public int PowerReceived = 3;
 
     /// <summary>
+    /// Punch the generator into functionality! Ratbite code
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField("punchPower")]
+    public int PunchPowerReceived = 2;
+
+    /// <summary>
     /// How much power should this field generator lose if not powered?
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
+++ b/Content.Shared/Singularity/Components/ContainmentFieldGeneratorComponent.cs
@@ -86,7 +86,7 @@ public sealed partial class ContainmentFieldGeneratorComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("powerMinimum")]
-    public int PowerMinimum = 6;
+    public int PowerMinimum = 3;
 
     /// <summary>
     /// How much power should this field generator receive from a collision

--- a/Content.Shared/Singularity/Components/EventHorizonComponent.cs
+++ b/Content.Shared/Singularity/Components/EventHorizonComponent.cs
@@ -77,6 +77,12 @@ public sealed partial class EventHorizonComponent : Component
     [ViewVariables(VVAccess.ReadOnly)]
     public bool BeingConsumedByAnotherEventHorizon = false;
 
+    [ViewVariables(VVAccess.ReadOnly)]
+    public int LowestPowerGenBuffer = 25;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public HashSet<Entity<ContainmentFieldGeneratorComponent>> ContainingFieldGenerators = new();
+
     #region Update Timing
 
     /// <summary>

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -117,6 +117,9 @@ public sealed partial class EmitterComponent : Component
     /// </summary>
     [DataField("setTypePorts", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<string, SinkPortPrototype>))]
     public Dictionary<string, string> SetTypePorts = new();
+
+    [DataField]
+    public TimeSpan PowerOffDelay = TimeSpan.FromSeconds(0);
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -18,12 +18,14 @@
 
 using System.Threading;
 using Content.Shared.DeviceLinking;
+using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
 namespace Content.Shared.Singularity.Components;
 
@@ -120,6 +122,15 @@ public sealed partial class EmitterComponent : Component
 
     [DataField]
     public TimeSpan PowerOffDelay = TimeSpan.FromSeconds(0);
+
+    [DataField]
+    public TimeSpan NextWarning = TimeSpan.Zero;
+
+    [DataField]
+    public TimeSpan WarningCooldown = TimeSpan.FromSeconds(15);
+
+    [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
+    public HashSet<string> WarningChannels = new();
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -22,6 +22,7 @@ using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
@@ -123,7 +124,7 @@ public sealed partial class EmitterComponent : Component
     [DataField]
     public TimeSpan PowerOffDelay = TimeSpan.FromSeconds(0);
 
-    [DataField]
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextWarning = TimeSpan.Zero;
 
     [DataField]

--- a/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
+++ b/Content.Shared/Singularity/Components/SharedEmitterComponent.cs
@@ -130,8 +130,8 @@ public sealed partial class EmitterComponent : Component
     [DataField]
     public TimeSpan WarningCooldown = TimeSpan.FromSeconds(15);
 
-    [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
-    public HashSet<string> WarningChannels = new();
+    [DataField]
+    public HashSet<ProtoId<RadioChannelPrototype>> WarningChannels = new();
 }
 
 [NetSerializable, Serializable]

--- a/Content.Shared/Singularity/Events/PowerOffDoAfterEvent.cs
+++ b/Content.Shared/Singularity/Events/PowerOffDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Singularity.Events;
+
+[Serializable, NetSerializable]
+public sealed partial class PowerOffDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -122,9 +122,7 @@ public abstract partial class SharedToolSystem
         var anchored = _maps.GetAnchoredEntities(gridUid, mapGrid, clickLocation);
         var tilePryEvent = new ToolPryAttemptEvent(user, ent);
         foreach (var anchor in anchored)
-        {
             RaiseLocalEvent(anchor, tilePryEvent);
-        }
 
         if (tilePryEvent.Cancelled)
             return false;

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -119,6 +119,15 @@ public abstract partial class SharedToolSystem
 
         var tileRef = _maps.GetTileRef(gridUid, mapGrid, clickLocation);
         var tileDef = (ContentTileDefinition) _tileDefManager[tileRef.Tile.TypeId];
+        var anchored = _maps.GetAnchoredEntities(gridUid, mapGrid, clickLocation);
+        var tilePryEvent = new ToolPryAttemptEvent(user, ent);
+        foreach (var anchor in anchored)
+        {
+            RaiseLocalEvent(anchor, tilePryEvent);
+        }
+
+        if (tilePryEvent.Cancelled)
+            return false;
 
         if (!tool.Qualities.ContainsAny(tileDef.DeconstructTools))
             return false;

--- a/Content.Shared/Tools/Systems/ToolPryAttemptEvent.cs
+++ b/Content.Shared/Tools/Systems/ToolPryAttemptEvent.cs
@@ -1,0 +1,17 @@
+namespace Content.Shared.Tools.Systems;
+
+/// <summary>
+///     Checks that entity can be weld/unweld.
+///     Raised twice: before do_after and after to check that entity still valid.
+/// </summary>
+public sealed class ToolPryAttemptEvent : CancellableEntityEventArgs
+{
+    public readonly EntityUid User;
+    public readonly EntityUid Tool;
+
+    public ToolPryAttemptEvent(EntityUid user, EntityUid tool)
+    {
+        User = user;
+        Tool = tool;
+    }
+}

--- a/Content.Shared/Tools/Systems/ToolPryAttemptEvent.cs
+++ b/Content.Shared/Tools/Systems/ToolPryAttemptEvent.cs
@@ -1,8 +1,8 @@
 namespace Content.Shared.Tools.Systems;
 
 /// <summary>
-///     Checks that entity can be weld/unweld.
-///     Raised twice: before do_after and after to check that entity still valid.
+///     Sent when someone is attempting to pry a tile beneath an entity.
+///     Every entity on the tile will be sent this event.
 /// </summary>
 public sealed class ToolPryAttemptEvent : CancellableEntityEventArgs
 {

--- a/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
+++ b/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared._BRatbite.PryBlocker;
+
+/// <summary>
+/// This is used for...
+/// </summary>
+[RegisterComponent]
+public sealed partial class PryBlockerComponent : Component
+{
+    
+}

--- a/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
+++ b/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
@@ -1,7 +1,8 @@
 namespace Content.Shared._BRatbite.PryBlocker;
 
 /// <summary>
-/// This is used for...
+/// This is used for preventing tiles from being pried beneath an anchored entity with this component.
+/// Primarily for preventing lattice beneath field generators being cut.
 /// </summary>
 [RegisterComponent]
 public sealed partial class PryBlockerComponent : Component;

--- a/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
+++ b/Content.Shared/_BRatbite/PryBlocker/PryBlockerComponent.cs
@@ -4,7 +4,4 @@ namespace Content.Shared._BRatbite.PryBlocker;
 /// This is used for...
 /// </summary>
 [RegisterComponent]
-public sealed partial class PryBlockerComponent : Component
-{
-    
-}
+public sealed partial class PryBlockerComponent : Component;

--- a/Content.Shared/_BRatbite/PryBlocker/PryBlockerSystem.cs
+++ b/Content.Shared/_BRatbite/PryBlocker/PryBlockerSystem.cs
@@ -13,8 +13,6 @@ public sealed class PryBlockerSystem : EntitySystem
         SubscribeLocalEvent<PryBlockerComponent, ToolPryAttemptEvent>(OnToolPryAttempt);
     }
 
-    private void OnToolPryAttempt(Entity<PryBlockerComponent> ent, ref ToolPryAttemptEvent args)
-    {
+    private void OnToolPryAttempt(Entity<PryBlockerComponent> ent, ref ToolPryAttemptEvent args) =>
         args.Cancel();
-    }
 }

--- a/Content.Shared/_BRatbite/PryBlocker/PryBlockerSystem.cs
+++ b/Content.Shared/_BRatbite/PryBlocker/PryBlockerSystem.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Tools.Systems;
+
+namespace Content.Shared._BRatbite.PryBlocker;
+
+/// <summary>
+/// This handles...
+/// </summary>
+public sealed class PryBlockerSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PryBlockerComponent, ToolPryAttemptEvent>(OnToolPryAttempt);
+    }
+
+    private void OnToolPryAttempt(Entity<PryBlockerComponent> ent, ref ToolPryAttemptEvent args)
+    {
+        args.Cancel();
+    }
+}

--- a/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
+++ b/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
@@ -12,3 +12,5 @@ containment-field-buffer-drop-loose =
 containment-field-emitter-powering-off =
     Note: A containment field emitter is currently being powered off.
     ID of individual performing action: {$id}
+
+containment-field-emitter-no-id-found = no ID found

--- a/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
+++ b/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
@@ -11,3 +11,4 @@ containment-field-buffer-drop-loose =
 
 containment-field-emitter-powering-off =
     Note: A containment field emitter is currently being powered off.
+    ID of individual performing action: {$id}

--- a/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
+++ b/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
@@ -8,3 +8,6 @@ containment-field-buffer-drop-emergency =
 
 containment-field-buffer-drop-loose =
     SINGULO/TESLA LOOSE IMMINENT! Containment field failing.
+
+containment-field-emitter-powering-off =
+    Note: A containment field emitter is currently being powered off.

--- a/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
+++ b/Resources/Locale/en-US/_BRatbite/containment-field/containment-field-announcements.ftl
@@ -1,0 +1,10 @@
+containment-field-announcement = Singularity/Tesla Containment Field System
+
+containment-field-buffer-drop-warning =
+    Warning! Singularity/Tesla containment field is losing charge! Buffer: {$buffer}%.
+
+containment-field-buffer-drop-emergency =
+    DANGER! Singularity/Tesla containment field reaching critical levels! Buffer: {$buffer}%.
+
+containment-field-buffer-drop-loose =
+    SINGULO/TESLA LOOSE IMMINENT! Containment field failing.

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -203,6 +203,17 @@
   flatReductions:
     Blunt: 5
 
+- type: damageModifierSet #Ratbite - NoDamage modifier for registering hit without damage, for Containment Field Generator
+  id: NoDamage
+  coefficients:
+    Blunt: 0.0
+    Slash: 0.0
+    Piercing: 0.0
+    Shock: 0.0
+    Cold: 0.0
+    Heat: 0.0
+    Caustic: 0.0
+
 - type: damageModifierSet
   id: Web # Very flammable, can be easily hacked and slashed, but shooting or hitting it is another story.
   coefficients:

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -203,17 +203,6 @@
   flatReductions:
     Blunt: 5
 
-- type: damageModifierSet #Ratbite - NoDamage modifier for registering hit without damage, for Containment Field Generator
-  id: NoDamage
-  coefficients:
-    Blunt: 0.0
-    Slash: 0.0
-    Piercing: 0.0
-    Shock: 0.0
-    Cold: 0.0
-    Heat: 0.0
-    Caustic: 0.0
-
 - type: damageModifierSet
   id: Web # Very flammable, can be easily hacked and slashed, but shooting or hitting it is another story.
   coefficients:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/containment.yml
@@ -60,6 +60,8 @@
     sprite: Structures/Power/Generation/Singularity/containment.rsi
     state: icon
   - type: ContainmentFieldGenerator
+  - type: Damageable #Ratbite - So that Generators can detect melee hits, they cant actually be destroyed by normal weapons.
+    damageModifierSet: NoDamage
   - type: PointLight
     enabled: false
     color: "#4080FF"

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -74,6 +74,9 @@
       map: ["enum.LockVisualLayers.Lock"]
   - type: Emitter
     powerOffDelay: 15
+    channels:
+    - Security
+    - Engineering
   - type: Gun
     showExamineText: false
     fireRate: 10 #just has to be fast enough to keep up with upgrades

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -73,6 +73,7 @@
       visible: false
       map: ["enum.LockVisualLayers.Lock"]
   - type: Emitter
+    powerOffDelay: 15
   - type: Gun
     showExamineText: false
     fireRate: 10 #just has to be fast enough to keep up with upgrades

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/emitter.yml
@@ -73,8 +73,8 @@
       visible: false
       map: ["enum.LockVisualLayers.Lock"]
   - type: Emitter
-    powerOffDelay: 15
-    channels:
+    powerOffDelay: 15 #Ratbite - Power Safety
+    channels: #Ratbite - Power Safety
     - Security
     - Engineering
   - type: Gun

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -118,8 +118,8 @@
     interfaces:
       enum.AmeControllerUiKey.Key:
         type: AmeControllerBoundUserInterface
-  - type: ActivatableUIRequiresAccess
-  - type: AccessReader
+  - type: ActivatableUIRequiresAccess #Ratbite - Power Safety
+  - type: AccessReader #Ratbite - Power Safety
     access: [ [ "Engineering" ] ]
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/ame.yml
@@ -118,6 +118,9 @@
     interfaces:
       enum.AmeControllerUiKey.Key:
         type: AmeControllerBoundUserInterface
+  - type: ActivatableUIRequiresAccess
+  - type: AccessReader
+    access: [ [ "Engineering" ] ]
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_BRatbite/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_BRatbite/Damage/modifier_sets.yml
@@ -1,0 +1,10 @@
+- type: damageModifierSet #Ratbite - NoDamage modifier for registering hit without damage, for Containment Field Generator
+  id: NoDamage
+  coefficients:
+    Blunt: 0.0
+    Slash: 0.0
+    Piercing: 0.0
+    Shock: 0.0
+    Cold: 0.0
+    Heat: 0.0
+    Caustic: 0.0


### PR DESCRIPTION
### Makes various changes to the more hazardous power production methods

- Emitters have a doafter for powering off
- Emitters will report to Engineering and Security when someone starts deactivating them. Cooldown of 15 seconds to prevent spam.
- Field Generators that contain a singularity will report charge drops to everyone through announcements. The thresholds are 75%, 50%, 25%, 10%, and 0%
- Field Generators will gain charge on melee hits, to prevent field shutdown in emergencies.
- The tile underneath an anchored Field Generator can no longer be removed.
- AME UI is restricted to engineering access.
- AME no longer explodes on overload. Instead, each bit of extra fuel provides less and less energy.