### PR TITLE
Perma ghost role removal

### DIFF
--- a/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
+++ b/Content.Server/Ghost/Roles/Components/GhostRoleComponent.cs
@@ -67,6 +67,9 @@ public sealed partial class GhostRoleComponent : Component
     [DataField("prob")]
     public float Probability = 1f;
 
+    [DataField("allowPerma")]
+    public bool AllowPerma = false;
+
     // We do this so updating RoleName and RoleDescription in VV updates the open EUIs.
 
     [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -43,6 +43,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using System.Linq;
+using Content.Server._BRatbite.PermaBrig;
 using Content.Server.Administration.Logs;
 using Content.Server.EUI;
 using Content.Server.Ghost.Roles.Components;
@@ -95,6 +96,7 @@ public sealed class GhostRoleSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly PermaBrigManager _permaManager = default!;
 
     private uint _nextRoleIdentifier;
     private bool _needsUpdateGhostRoleCount = true;
@@ -507,6 +509,15 @@ public sealed class GhostRoleSystem : EntitySystem
 
         if (!_ghostRoles.TryGetValue(identifier, out var roleEnt))
             return;
+
+        if (!roleEnt.Comp.AllowPerma)
+        {
+            if (_permaManager.GetBrigSentence(player.UserId) > 0)
+            {
+                _popupSystem.PopupCursor(Loc.GetString("perma-deny-ghost-role"), player);
+                return;
+            }
+        }
 
         if (roleEnt.Comp.RaffleConfig is not null)
         {

--- a/Resources/Locale/en-US/_BRatbite/perma/prisoner.ftl
+++ b/Resources/Locale/en-US/_BRatbite/perma/prisoner.ftl
@@ -2,3 +2,5 @@ perma-prisoner-briefing =
     You have been locked up for your crimes!
     Serve your sentence, and you will be allowed to return to work on the station.
     you have {$rounds} rounds left in your sentence.
+
+perma-deny-ghost-role = Perma prisoners cant take this ghost role!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1993,6 +1993,7 @@
     makeSentient: true
     allowSpeech: true
     allowMovement: true
+    allowPerma: true
     name: ghost-role-information-mouse-name
     description: ghost-role-information-mouse-description
     rules: ghost-role-information-freeagent-rules


### PR DESCRIPTION
Made it so those with a perma sentence cannot pick ghost roles, unless said ghost role has the attribute "allowPerma: true"

Currently, only mice have been given the said attribute