### PR TITLE
Map File Capitalization Fix

### DIFF
--- a/Resources/Prototypes/Maps/amber.yml
+++ b/Resources/Prototypes/Maps/amber.yml
@@ -31,7 +31,7 @@
 - type: gameMap
   id: Amber
   mapName: 'Amber'
-  mapPath: /Maps/_BRatbite/Ratbite_Supported/Amber.yml
+  mapPath: /Maps/_BRatbite/Ratbite_Supported/amber.yml
   minPlayers: 20
   maxPlayers: 60
   stations:

--- a/Resources/Prototypes/Maps/core.yml
+++ b/Resources/Prototypes/Maps/core.yml
@@ -28,7 +28,7 @@
 - type: gameMap
   id: Core
   mapName: 'Core'
-  mapPath: /Maps/_BRatbite/Ratbite_Supported/Core.yml # Ratbite
+  mapPath: /Maps/_BRatbite/Ratbite_Supported/core.yml # Ratbite
   minPlayers: 50
   maxPlayers: 80
   stations:

--- a/Resources/Prototypes/Maps/omega.yml
+++ b/Resources/Prototypes/Maps/omega.yml
@@ -32,7 +32,7 @@
 - type: gameMap
   id: Omega
   mapName: 'Omega'
-  mapPath: /Maps/_BRatbite/Ratbite_Supported/Omega.yml
+  mapPath: /Maps/_BRatbite/Ratbite_Supported/omega.yml
   minPlayers: 15
   maxPlayers: 45
   stations:

--- a/Resources/Prototypes/Maps/packed.yml
+++ b/Resources/Prototypes/Maps/packed.yml
@@ -34,7 +34,7 @@
 - type: gameMap
   id: Packed
   mapName: 'Packed'
-  mapPath: /Maps/_BRatbite/Ratbite_Supported/Packed.yml
+  mapPath: /Maps/_BRatbite/Ratbite_Supported/packed.yml
   minPlayers: 13
   maxPlayers: 45
   stations:

--- a/Resources/Prototypes/Maps/saltern.yml
+++ b/Resources/Prototypes/Maps/saltern.yml
@@ -32,7 +32,7 @@
 - type: gameMap
   id: Saltern
   mapName: 'Saltern'
-  mapPath: /Maps/_BRatbite/Ratbite_Supported/Saltern.yml
+  mapPath: /Maps/_BRatbite/Ratbite_Supported/saltern.yml
   minPlayers: 10
   maxPlayers: 45
   fallback: true


### PR DESCRIPTION
Map paths had incorrect capitalization. This wasn't a problem for Windows, as its file paths are not case-sensitive. For Linux, however, it could not find the map paths with incorrect capitalization.