### PR TITLE
[BUG FIX] Makes borg airloss immune and ports "Necksnap Sloppitude"

### DIFF
--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.CQC.cs
@@ -2,9 +2,13 @@
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
+// SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+Baptr0b0t@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+baptr0b0t@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Lincoln McQueen <lincoln.mcqueen@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
 //
@@ -22,6 +26,7 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared.Body.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
@@ -124,11 +129,15 @@ public partial class SharedMartialArtsSystem
                     TryComp(ent, out PullerComponent? puller) && puller.Pulling == args.Target &&
                     TryComp(args.Target, out PullableComponent? pullable) &&
                     TryComp(args.Target, out BodyComponent? body) &&
+                    TryComp(args.Target, out StaminaComponent? stamina) && stamina.Critical &&
                     puller.GrabStage == GrabStage.Suffocate && TryComp(ent, out TargetingComponent? targeting) &&
-                    targeting.Target == TargetBodyPart.Head)
+                    targeting.Target == TargetBodyPart.Head
+                    && _mobThreshold.TryGetDeadThreshold(args.Target, out var damageToKill))
                 {
                     _pulling.TryStopPull(args.Target, pullable);
-                    _mobState.ChangeMobState(args.Target, MobState.Dead, null, ent);
+
+                    var blunt = new DamageSpecifier(_proto.Index<DamageTypePrototype>("Blunt"), damageToKill.Value);
+                    _damageable.TryChangeDamage(args.Target, blunt, true, targetPart: TargetBodyPart.Chest);
 
                     var (partType, symmetry) = _body.ConvertTargetBodyPart(targeting.Target);
                     var targetedBodyPart = _body.GetBodyChildrenOfType(args.Target, partType, body, symmetry)

--- a/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
+++ b/Content.Goobstation.Shared/MartialArts/SharedMartialArtsSystem.cs
@@ -1,12 +1,19 @@
 // SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2025 August Eymann <august.eymann@gmail.com>
+// SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Aviu00 <aviu00@protonmail.com>
+// SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+Baptr0b0t@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Baptr0b0t <152836416+baptr0b0t@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 GoobBot <uristmchands@proton.me>
 // SPDX-FileCopyrightText: 2025 Lincoln McQueen <lincoln.mcqueen@gmail.com>
 // SPDX-FileCopyrightText: 2025 Marcus F <marcus2008stoke@gmail.com>
 // SPDX-FileCopyrightText: 2025 Misandry <mary@thughunt.ing>
+// SPDX-FileCopyrightText: 2025 SX-7 <sn1.test.preria.2002@gmail.com>
+// SPDX-FileCopyrightText: 2025 Solstice <solsticeofthewinter@gmail.com>
+// SPDX-FileCopyrightText: 2025 SolsticeOfTheWinter <solsticeofthewinter@gmail.com>
 // SPDX-FileCopyrightText: 2025 Ted Lukin <66275205+pheenty@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 gluesniffler <linebarrelerenthusiast@gmail.com>
 // SPDX-FileCopyrightText: 2025 gus <august.eymann@gmail.com>
 // SPDX-FileCopyrightText: 2025 pheenty <fedorlukin2006@gmail.com>
@@ -92,6 +99,7 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
     [Dependency] private readonly NpcFactionSystem _faction = default!;
     [Dependency] private readonly SharedBodySystem _body = default!;
     [Dependency] private readonly TraumaSystem _trauma = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
 
     public override void Initialize()
     {
@@ -485,10 +493,26 @@ public abstract partial class SharedMartialArtsSystem : EntitySystem
             case MartialArtsForms.Ninjutsu:
                 EnsureComp<NinjutsuSneakAttackComponent>(user);
                 break;
+            case MartialArtsForms.CloseQuartersCombat:
+                var riposte = EnsureComp<RiposteeComponent>(user);
+                riposte.Data.TryAdd("CQC",
+                    new(0.1f,
+                    false,
+                    null,
+                    true,
+                    new SoundPathSpecifier("/Audio/Weapons/genhit1.ogg"),
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(4),
+                    false,
+                    0.75f,
+                    null,
+                    null,
+                    new CanDoCQCEvent()));
+                break;
         }
 
         martialArtsKnowledgeComponent.MartialArtsForm = martialArtsPrototype.MartialArtsForm;
-        martialArtsKnowledgeComponent.StartingStage = martialArtsPrototype.StartingStage;
+        //martialArtsKnowledgeComponent.StartingStage = martialArtsPrototype.StartingStage;
         LoadCombos(martialArtsPrototype.RoundstartCombos, canPerformComboComponent);
         martialArtsKnowledgeComponent.Blocked = false;
 

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -32,10 +32,12 @@
   id: Silicon
   coefficients:
     Heat: 0.8
+    Asphyxiation: 0.0 #Ratbites, Airloss isnt repairable, why can they take it?
   flatReductions:
     Blunt: 5
     Slash: 5
     Piercing: 5
+    Asphyxiation: 100 #Ratbites, Airloss isnt repairable, why can they take it?
 
 - type: damageModifierSet
   id: SiliconProtected
@@ -44,10 +46,12 @@
     Slash: 0.6
     Piercing: 0.6
     Heat: 0.5
+    Asphyxiation: 0.0 #Ratbites, Airloss isnt repairable, why can they take it?
   flatReductions:
     Blunt: 5
     Slash: 5
     Piercing: 5
+    Asphyxiation: 100 #Ratbites, Airloss isnt repairable, why can they take it?
 
 - type: damageModifierSet
   id: Yowie


### PR DESCRIPTION
### What is it?
Ports ["Necksnap Sloppitude"](https://github.com/Goob-Station/Goob-Station/pull/3475) and makes borgs immune to airloss damage to fix [this](https://github.com/RatBite-Station-14/Rat_Bite_Station_14/issues/52).

### Changelog
:cl:
- add: ports the Necksnap Sloppitude, fixing most bugs related to necksnap.
- tweak: Makes borgs immune to airloss damage.