### PR TITLE
Properly get rid of power out events along with making both borgs and abductors rare.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -151,7 +151,7 @@
     - id: AnomalySpawn
     - id: BluespaceArtifact
     - id: BluespaceLocker
-    - id: BreakerFlip
+    #- id: BreakerFlip #RatBite
     - id: BureaucraticError
     - id: ClericalError
     - id: CockroachMigration
@@ -162,7 +162,7 @@
     - id: MassHallucinations
     - id: MimicVendorRule
     - id: MouseMigration
-    - id: PowerGridCheck
+    #- id: PowerGridCheck #RatBite
     - id: RandomSentience
     - id: SlimesSpawn
     - id: SolarFlare
@@ -333,7 +333,7 @@
   id: ClosetSkeleton
   components:
   - type: StationEvent
-    weight: 5
+    weight: 3
     duration: 1
     minimumPlayers: 10
     eventType: Chaotic # Goobstation
@@ -1003,7 +1003,7 @@
   id: DerelictCyborgSpawn
   components:
   - type: StationEvent
-    weight: 5
+    weight: 1
     earliestStart: 15
     reoccurrenceDelay: 20
     minimumPlayers: 4

--- a/Resources/Prototypes/_Goobstation/GameRules/events.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/events.yml
@@ -32,7 +32,7 @@
   - type: GameRule
     chaosScore: 150
   - type: StationEvent
-    weight: 6 # Rare, but not AS rare
+    weight: 1 # RatBite
     earliestStart: 15
     reoccurrenceDelay: 20
     minimumPlayers: 4

--- a/Resources/Prototypes/_Shitmed/GameRules/events.yml
+++ b/Resources/Prototypes/_Shitmed/GameRules/events.yml
@@ -19,7 +19,7 @@
   - type: StationEvent
     earliestStart: 15
     reoccurrenceDelay: 45
-    weight: 7.5
+    weight: 1 #RatBite
     minimumPlayers: 10
     duration: 1
     chaos:
@@ -118,7 +118,7 @@
   - type: StationEvent
     earliestStart: 15
     reoccurrenceDelay: 45
-    weight: 7.5
+    weight: 1 #RatBite
     minimumPlayers: 20
     duration: 1
     chaos:


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fix my last PR about fixing the power along with making both abductors and borgs rare. Lowered skeleton spawn rates as well (as I already can predict there would be way too many of them)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People didnt like either the power out events nor the abductor and borg spam.
## Technical details
<!-- Summary of code changes for easier review. -->
Removed the power event from the pool so no longer chosen (fixed da fix)
Changed the weights of the other events mentioned.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed the removal of power out events.
- tweak: Lowered abductor spawn rates to make them rare.
- tweak: Lowered borg spawn rates to make them rare too.
- tweak: Lowered skeleton spawn rates as they would become the new spam otherwise.
