### PR TITLE
Lasers buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -54,7 +54,7 @@
   id: RedLaser
   damage:
     types:
-      Heat: 14
+      Heat: 16 #Ratbite
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -84,7 +84,7 @@
   id: RedMediumLaser
   damage:
     types:
-      Heat: 19 #RatBite
+      Heat: 21 #RatBite
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -99,7 +99,7 @@
   id: RedLightLaser
   damage:
     types:
-      Heat: 7
+      Heat: 10 #Ratbite
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -114,8 +114,8 @@
   id: XrayLaser
   damage:
     types:
-      Heat: 10
-      Radiation: 10
+      Heat: 8 #Ratbite
+      Radiation: 15 #Ratbite
       Ion: 15 #Goobstation
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
@@ -131,7 +131,8 @@
   id: RedHeavyLaser
   damage:
     types:
-      Heat: 28
+      Heat: 30 #Ratbite
+      Ion: 10 #Ratbite
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy
@@ -147,7 +148,7 @@
   damage:
     types:
       Heat: 30 # Goobstation
-      Blunt: 5 # Split damage is cool. - Goobstation
+      #Blunt: 5 # Split damage is cool. - Goobstation, removed split damage from pulse - Ratbite.
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_blue
@@ -164,7 +165,7 @@
   damage:
     types:
       Heat: 45
-      Structural: 10
+      Structural: 20 #Ratbite
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -7,7 +7,7 @@
   id: SmallRedLaser
   damage:
     types:
-      Heat: 7
+      Heat: 9 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light
@@ -37,8 +37,8 @@
   id: SmallXrayLaser
   damage:
     types:
-      Heat: 3
-      Radiation: 4
+      Heat: 2 #Ratbite
+      Radiation: 6 #Ratbie
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_xray
@@ -54,7 +54,7 @@
   fireStacks: 0.4
   damage:
     types:
-      Heat: 10
+      Heat: 13 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_overcharged
@@ -69,7 +69,7 @@
   id: SmallPulseLaser
   damage:
     types:
-      Heat: 12
+      Heat: 14 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_pulse
@@ -84,7 +84,7 @@
   id: MediumRedLaser
   damage:
     types:
-      Heat: 10
+      Heat: 15 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light
@@ -114,8 +114,8 @@
   id: MediumXrayLaser
   damage:
     types:
-      Heat: 5
-      Radiation: 5
+      Heat: 6 #Ratbite
+      Radiation: 8 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_xray
@@ -131,7 +131,7 @@
   fireStacks: 0.7
   damage:
     types:
-      Heat: 14
+      Heat: 17 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_overcharged
@@ -146,7 +146,7 @@
   id: MediumPulseLaser
   damage:
     types:
-      Heat: 17
+      Heat: 19 #Ratbite
   muzzleFlash:
     sprite: _Goobstation/Objects/Weapons/Guns/Projectiles/small_laser.rsi
     state: muzzle_beam_light_pulse


### PR DESCRIPTION

## About the PR
Buffed Wizden and Goob lasers.
Almost all lasers have recieved damage increases.

## Why / Balance
Many members of the community have displayed displesure at the lack of power behind lasers, a small boost in damage should show if Lasers are truley bad or if its just not being used in the current META.

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: FloraMillhouse
- tweak: Buffed lasers damage values.


