### PR TITLE
[HOTFIX] make jlb speaker admin only until fix

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -272,8 +272,6 @@
       prob: 0.15
     - id: DoorJack
       prob: 0.05 #Goob content
-    - id: MoblileSpeaker
-      prob: 0.1 #Ratbite
     # Tools
     - !type:NestedSelector
       tableId: MaintToolsTable

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -233,7 +233,6 @@
       children:
       - id: ClothingNeckCloakHerald
       - id: ClothingHeadHelmetTemplar
-      - id: MoblileSpeaker #Ratbite
       # Cloaks
       - !type:GroupSelector
         children:


### PR DESCRIPTION
JLB speaker has been making issues for some reason

🆑 
- remove: removes the JLB speaker from maints, making it admin only