### PR TITLE
Port of "Healing auto target limbs #4375"

### DIFF
--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -84,6 +84,7 @@ using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Robust.Shared.Network;
 using System.Linq;
 
 
@@ -108,6 +109,9 @@ public sealed class HealingSystem : EntitySystem
     [Dependency] private readonly SharedTargetingSystem _targetingSystem = default!;
     [Dependency] private readonly TraumaSystem _trauma = default!;
     [Dependency] private readonly WoundSystem _wounds = default!;
+
+    // Goobstation edit
+    [Dependency] private readonly INetManager _net = default!;
 
     public override void Initialize()
     {
@@ -236,24 +240,45 @@ public sealed class HealingSystem : EntitySystem
     private string? GetDamageGroupByType(string id)
         => (from @group in _prototypes.EnumeratePrototypes<DamageGroupPrototype>() where @group.DamageTypes.Contains(id) select @group.ID).FirstOrDefault();
 
-    private bool IsBodyDamaged(Entity<BodyComponent> target, EntityUid user, HealingComponent healing)
+
+    // Goobstation start
+    /// <summary>
+    /// Method <c>IsBodyDamaged</c> returns if a body part can be healed by the healing component. Returns false part is fully healed too.
+    /// </summary>
+    /// <param name="target">the target Entity</param>
+    /// <param name="user">The person trying to heal. (optional)</param>
+    /// <param name="healing">The healing component.</param>
+    /// <param name="targetedPart">bypasses targeting system to specify a limb. Must be set if user is null. (optional)</param>
+    /// <returns> Wether or not the targeted part can be healed. </returns>
+    private bool IsBodyDamaged(Entity<BodyComponent> target, EntityUid? user, HealingComponent healing, EntityUid? targetedPart = null)
     {
-        if (!TryComp<TargetingComponent>(user, out var targeting))
+
+        if (user is null && targetedPart is null) // no limb can be targeted at all
             return false;
 
-        var (partType, symmetry) = _bodySystem.ConvertTargetBodyPart(targeting.Target);
-        var targetedBodyPart = _bodySystem.GetBodyChildrenOfType(target, partType, target, symmetry).ToList().FirstOrNull();
-
-        if (targetedBodyPart == null
-            || !TryComp(targetedBodyPart.Value.Id, out DamageableComponent? damageable))
+        if (user is not null)
         {
-            _popupSystem.PopupEntity(Loc.GetString("does-not-exist-rebell"), target, user, PopupType.MediumCaution);
+            if (!TryComp<TargetingComponent>(user, out var targeting))
+                return false;
+
+            var (partType, symmetry) = _bodySystem.ConvertTargetBodyPart(targeting.Target);
+            var targetedBodyPart = _bodySystem.GetBodyChildrenOfType(target, partType, target, symmetry).ToList().FirstOrNull();
+
+            if (targetedBodyPart is not null && targetedPart is null)
+                targetedPart = targetedBodyPart.Value.Id;
+        }
+
+        if (targetedPart == null
+            || !TryComp(targetedPart, out DamageableComponent? damageable))
+        {
+            if (user is not null)
+                _popupSystem.PopupPredicted(Loc.GetString("missing-body-part"), target, user.Value, PopupType.MediumCaution);
             return false;
         }
 
         if (healing.Damage.DamageDict.Keys
             .Any(damageKey => _wounds.GetWoundableSeverityPoint(
-                targetedBodyPart.Value.Id,
+                targetedPart.Value,
                 damageGroup: GetDamageGroupByType(damageKey),
                 healable: true) > 0 || damageable.Damage.DamageDict[damageKey].Value > 0))
             return true;
@@ -261,14 +286,35 @@ public sealed class HealingSystem : EntitySystem
         if (healing.BloodlossModifier == 0)
             return false;
 
-        foreach (var wound in _wounds.GetWoundableWounds(targetedBodyPart.Value.Id))
+        foreach (var wound in _wounds.GetWoundableWounds(targetedPart.Value))
         {
             if (!TryComp<BleedInflicterComponent>(wound, out var bleeds) || !bleeds.IsBleeding)
                 continue;
 
             return true;
         }
+        // Goobstation end
 
+        return false;
+    }
+
+    /// <summary>
+    /// This function tries to return the first limb that has one of the damage type we are trying to heal
+    /// Returns true or false if next damaged part exists.
+    /// </summary>
+    private bool TryGetNextDamagedPart(EntityUid ent, HealingComponent healing, out EntityUid? part)
+    {
+        part = null;
+        if (!TryComp<BodyComponent>(ent, out var body))
+            return false;
+
+        var parts = _bodySystem.GetBodyChildren(ent, body).ToArray();
+        foreach (var limb in parts)
+        {
+            part = limb.Id;
+            if (IsBodyDamaged((ent, body), null, healing, limb.Id))
+                return true;
+        }
         return false;
     }
 
@@ -290,9 +336,15 @@ public sealed class HealingSystem : EntitySystem
             targetedWoundable = targetedBodyPart.Id;
         }
 
+        // Goobstation start
+        if (!IsBodyDamaged((ent, comp), null, healing, targetedWoundable)) // Check if there is anything to heal on the initial limb target
+            if (TryGetNextDamagedPart(ent, healing, out var limbTemp) && limbTemp is not null) // If not then get the next limb to heal
+                targetedWoundable = limbTemp.Value;
+        // Goobstation end
+
         if (targetedWoundable == EntityUid.Invalid)
         {
-            _popupSystem.PopupEntity(
+            _popupSystem.PopupPredicted(
                 Loc.GetString("medical-item-cant-use", ("item", args.Used)),
                 ent,
                 args.User,
@@ -314,7 +366,7 @@ public sealed class HealingSystem : EntitySystem
         {
             healedBleedWound = _wounds.TryHealBleedingWounds(targetedWoundable, healing.BloodlossModifier, out modifiedBleedStopAbility, woundableComp);
             if (healedBleedWound)
-                _popupSystem.PopupEntity(modifiedBleedStopAbility > 0
+                _popupSystem.PopupPredicted(modifiedBleedStopAbility > 0
                         ? Loc.GetString("rebell-medical-item-stop-bleeding-fully")
                         : Loc.GetString("rebell-medical-item-stop-bleeding-partially"),
                     ent,
@@ -341,7 +393,7 @@ public sealed class HealingSystem : EntitySystem
         }
         */
         // KS14 - we do NOT need dogshit healing capabilities thank you very much
-        var damageChanged = _damageable.TryChangeDamage(ent, healing.Damage * _damageable.UniversalTopicalsHealModifier, true, origin: args.User);
+        var damageChanged = _damageable.TryChangeDamage(targetedWoundable, healing.Damage * _damageable.UniversalTopicalsHealModifier, true, origin: args.User); // GOOBEDIT
 
         if (damageChanged is not null)
             healedTotal += -damageChanged.GetTotal();
@@ -349,18 +401,9 @@ public sealed class HealingSystem : EntitySystem
         if (healedTotal <= 0 && !healedBleed)
         {
             if (healing.BloodlossModifier == 0 && woundableComp.Bleeds > 0) // If the healing item has no bleeding heals, and its bleeding, we raise the alert.
-                _popupSystem.PopupEntity(Loc.GetString("medical-item-cant-use-rebell", ("target", ent)), ent, args.User);
+                _popupSystem.PopupPredicted(Loc.GetString("medical-item-cant-use-rebell", ("target", ent)), ent, args.User);
 
-            if (damageChanged is not null)
-                healedTotal += -damageChanged.GetTotal();
-
-            if (healedTotal <= 0 && !healedBleed)
-            {
-                if (healing.BloodlossModifier == 0 && woundableComp.Bleeds > 0) // If the healing item has no bleeding heals, and its bleeding, we raise the alert.
-                    _popupSystem.PopupEntity(Loc.GetString("medical-item-cant-use-rebell", ("target", ent)), ent, args.User);
-
-                return;
-            }
+            return;
         }
 
 
@@ -388,17 +431,17 @@ public sealed class HealingSystem : EntitySystem
                 $"{EntityManager.ToPrettyString(args.User):user} healed themselves for {healedTotal:damage} damage");
         }
 
-        _audio.PlayPvs(healing.HealingEndSound, ent, AudioParams.Default.WithVariation(0.125f).WithVolume(1f));
+        _audio.PlayPredicted(healing.HealingEndSound, ent, ent, AudioParams.Default.WithVariation(0.125f).WithVolume(1f));
 
         // Logic to determine whether or not to repeat the healing action
-        args.Repeat = IsBodyDamaged((ent, comp), args.User, healing);
+        args.Repeat = IsAnythingToHeal(args.User, ent, (args.Used.Value, healing)); // GOOBEDIT
         args.Handled = true;
 
         if (args.Repeat || dontRepeat)
             return;
 
         if (modifiedBleedStopAbility != -healing.BloodlossModifier)
-            _popupSystem.PopupEntity(Loc.GetString("medical-item-finished-using", ("item", args.Used)), ent, args.User, PopupType.Medium);
+            _popupSystem.PopupPredicted(Loc.GetString("medical-item-finished-using", ("item", args.Used)), ent, args.User, PopupType.Medium);
     }
 
     // Shitmed Change End
@@ -420,6 +463,22 @@ public sealed class HealingSystem : EntitySystem
         if (TryHeal(entity, args.User, args.Target.Value, entity.Comp))
             args.Handled = true;
     }
+
+    // Goobstation start
+    private bool IsAnythingToHeal(EntityUid user, EntityUid target, Entity<HealingComponent> healing)
+    {
+        if (!TryComp<DamageableComponent>(target, out var targetDamage))
+            return false;
+
+        return HasDamage((target, targetDamage), healing.Comp) ||
+            TryComp<BodyComponent>(target, out var bodyComp) && // I'm paranoid, sorry.
+            IsBodyDamaged((target, bodyComp), user, healing.Comp) ||
+            healing.Comp.ModifyBloodLevel > 0 // Special case if healing item can restore lost blood...
+            && TryComp<BloodstreamComponent>(target, out var bloodstream)
+            && _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
+            && bloodSolution.Volume < bloodSolution.MaxVolume;
+    }
+    // Goobstation end
 
     private bool TryHeal(EntityUid uid, EntityUid user, EntityUid target, HealingComponent component)
     {

--- a/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
+++ b/Content.Shared/Body/Prototypes/BodyPrototypeSerializer.cs
@@ -189,3 +189,4 @@ public sealed class BodyPrototypeSerializer : ITypeReader<BodyPrototype, Mapping
         return new BodyPrototype(id, name, root, slots);
     }
 }
+


### PR DESCRIPTION
https://github.com/Goob-Station/Goob-Station/pull/4375
> ## About the PR
> Change how healing targets limbs. Now you can aim anywhere and it will heal every damaged limb one after the other without needing to micromanage the targeting system. The limb aimed at using the targeting system is still healed first if damaged.
> 
> ## Why / Balance
> Having to micromanage the limb targeting to heal is absolutely terrible. So QOL
> 
> ## Technical details
> Modified HealingSystem. Added an optional argument to "IsBodyDamaged" so that you can bypass the targeting system of the user.
> 
> I have tested chems, surgery and healing items. All seem to work as intended.
> 
> ## Media
> https://cdn.discordapp.com/attachments/1406680537464045762/1420458669299990629/2025-09-24_19-14-05.mp4?ex=68d578b9&is=68d42739&hm=ef43822ab109e2fae0fe14c9d60888fdd19769a2be0b846f3e127558025aca66&
> 
> ## Requirements
> * [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
> * [X ] I have added media to this PR or it does not require an ingame showcase.
> 
> **Changelog**
> 
> 🆑
> 
> * add: Topicals now automatically heal limbs one after the other.
> * bug: no more double sound when you heal someone

