### PR TITLE
Tweaks to the ghost orbit menu

### DIFF
--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
         <ScrollContainer Name="GhostScroll" VerticalExpand="True" HorizontalExpand="True" HScrollEnabled="False">
         <BoxContainer Orientation="Vertical" >
             <BoxContainer Name="AntagBox" HorizontalExpand="True" >
-                <Collapsible HorizontalExpand="True">
+                <Collapsible HorizontalExpand="True" BodyVisible="True">
                     <CollapsibleHeading Name="AntagonistHeading" />
                     <CollapsibleBody>
                         <GridContainer Name="AntagonistContainer" MaxGridWidth="440"/> <!-- These contain buttons on runtime-->
@@ -26,15 +26,23 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 </Collapsible>
             </BoxContainer>
             <BoxContainer HorizontalExpand="True" >
-                <Collapsible HorizontalExpand="True">
+                <Collapsible HorizontalExpand="True" BodyVisible="True">
                     <CollapsibleHeading Name="LivingHeading" />
                     <CollapsibleBody>
                         <GridContainer Name="LivingContainer" MaxGridWidth="440"/>
                     </CollapsibleBody>
                 </Collapsible>
             </BoxContainer>
+            <BoxContainer Name="DeadBox" HorizontalExpand="True" >
+                <Collapsible HorizontalExpand="True" BodyVisible="True">
+                    <CollapsibleHeading Name="DeadHeading" />
+                    <CollapsibleBody>
+                        <GridContainer Name="DeadContainer" MaxGridWidth="440"/>
+                    </CollapsibleBody>
+                </Collapsible>
+            </BoxContainer>
             <BoxContainer HorizontalExpand="True" >
-                <Collapsible HorizontalExpand="True">
+                <Collapsible HorizontalExpand="True" BodyVisible="True">
                     <CollapsibleHeading Name="GhostHeading" />
                     <CollapsibleBody>
                         <GridContainer Name="GhostContainer" MaxGridWidth="440"/>
@@ -42,7 +50,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
                 </Collapsible>
             </BoxContainer>
             <BoxContainer HorizontalExpand="True" >
-                <Collapsible HorizontalExpand="True">
+                <Collapsible HorizontalExpand="True" BodyVisible="True">
                     <CollapsibleHeading Name="MiscHeading" />
                     <CollapsibleBody>
                         <GridContainer Name="MiscContainer" MaxGridWidth="440"/>

--- a/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Ghost/Controls/GhostTargetWindow.xaml.cs
@@ -54,17 +54,21 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                 if (warp.Mob)
                 {
                     name = warp.DisplayName + (warp.Followers > 0 ? " f: " + warp.Followers : "");
-                    if (warp.Antagonist)
+                    if(warp.Player_ghost)
                     {
-                        type = 1;
+                        type = 4;
                     }
-                    else if(!warp.Player_ghost)
+                    else if (warp.IsDead)
+                    {
+                        type = 3;
+                    }
+                    else if (warp.Antagonist)
                     {
                         type = 2;
                     }
                     else
                     {
-                        type = 3;
+                        type = 1;
                     }
                 }
                 else
@@ -79,6 +83,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         {
             AntagonistContainer.DisposeAllChildren();
             LivingContainer.DisposeAllChildren();
+            DeadContainer.DisposeAllChildren();
             GhostContainer.DisposeAllChildren();
             MiscContainer.DisposeAllChildren();
             AddButtons();
@@ -88,6 +93,7 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
         {
             var total_antagonist_length = 0;
             var total_living_length = 0;
+            var total_dead_length = 0;
             var total_ghost_length = 0;
             var total_misc_length = 0;
             foreach (var (name, Entity, type) in Warps)
@@ -110,25 +116,31 @@ namespace Content.Client.UserInterface.Systems.Ghost.Controls
                         MiscContainer.AddChild(currentButtonRef);
                         continue;
                     case 1:
-                        total_antagonist_length++;
-                        AntagonistContainer.AddChild(currentButtonRef);
-                        continue;
-                    case 2:
                         total_living_length++;
                         LivingContainer.AddChild(currentButtonRef);
                         continue;
+                    case 2:
+                        total_antagonist_length++;
+                        AntagonistContainer.AddChild(currentButtonRef);
+                        continue;
                     case 3:
+                        total_dead_length++;
+                        DeadContainer.AddChild(currentButtonRef);
+                        continue;
+                    case 4:
                         total_ghost_length++;
                         GhostContainer.AddChild(currentButtonRef);
                         continue;
                 }
             }
-            MiscHeading.Title = "Misc - (" + total_misc_length + ")";
             AntagonistHeading.Title = "Antagonists - (" + total_antagonist_length + ")";
             LivingHeading.Title = "Alive - (" + total_living_length + ")";
+            DeadHeading.Title = "Dead - (" + total_dead_length + ")";
             GhostHeading.Title = "Ghosts - (" + total_ghost_length + ")";
-            // Only check this one for visibility, since the others will preety much always be visible
+            MiscHeading.Title = "Misc - (" + total_misc_length + ")";
+            // Only check these ones for visibility, since the others will preety much always be visible
             AntagBox.Visible = total_antagonist_length > 0;
+            DeadBox.Visible = total_dead_length > 0;
         }
 
         private bool ButtonIsVisible(Button button)

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -469,14 +469,16 @@ namespace Content.Server.Ghost
                         foreach(var _ in followComponent.Following)
                             followers++;
                     }
-                    if (TryComp<MindContainerComponent>(uid, out var mindContainer) && mindContainer.HasMind) // Remove to show all points for testing
+                    TryComp<MindContainerComponent>(uid, out var mind);
+                    if (mind?.Mind != null)
                     {
-                        yield return new GhostWarp(entity, warp.Location ?? Name(uid), warp.Mob, warp.Ghost, warp.Antagonist, followers);
+                        var player_name = $"{warp.Location ?? Name(uid)} ({_jobs.MindTryGetJobName(mind.Mind)})";
+                        yield return new GhostWarp(entity, player_name, warp.Mob, _mobState.IsDead(uid), warp.Ghost, warp.Antagonist, followers);
                     }
                 }
                 else
                 {
-                    yield return new GhostWarp(entity, warp.Location ?? Name(uid), warp.Mob, warp.Ghost, warp.Antagonist, 0);
+                    yield return new GhostWarp(entity, warp.Location ?? Name(uid), warp.Mob, true, warp.Ghost, warp.Antagonist, 0);
                 }
             }
         }
@@ -496,9 +498,10 @@ namespace Content.Server.Ghost
                 }
 
                 TryComp<MindContainerComponent>(attached, out var mind);
-                var playerInfo = $"{Comp<MetaDataComponent>(attached).EntityName}";
+                var jobName = _jobs.MindTryGetJobName(mind?.Mind);
+                var playerInfo = $"{Comp<MetaDataComponent>(attached).EntityName} ({jobName})";
 
-                yield return new GhostWarp(GetNetEntity(attached), playerInfo, false, false, false, 0);
+                yield return new GhostWarp(GetNetEntity(attached), playerInfo, true, _mobState.IsDead(attached), false, false, 0);
             }
         }
 

--- a/Content.Shared/Ghost/SharedGhostSystem.cs
+++ b/Content.Shared/Ghost/SharedGhostSystem.cs
@@ -167,11 +167,12 @@ namespace Content.Shared.Ghost
     [Serializable, NetSerializable]
     public struct GhostWarp
     {
-        public GhostWarp(NetEntity entity, string displayName, bool mob, bool ghost, bool antagonist, int followers)
+        public GhostWarp(NetEntity entity, string displayName, bool mob, bool isDead, bool ghost, bool antagonist, int followers)
         {
             Entity = entity;
             DisplayName = displayName;
             Mob = mob;
+            IsDead = isDead;
             Player_ghost = ghost;
             Antagonist = antagonist;
             Followers = followers;
@@ -190,8 +191,13 @@ namespace Content.Shared.Ghost
 
         /// <summary>
         ///     Tags that determine what category this point will go into in the ghost's orbit menu
+        ///     Mob: Is this a mob? If false, its a location
+        ///     IsDead: Is this mob dead?
+        ///     Player_ghost: Is this a ghost?
+        ///     Antagonist: Is this a visible antagonist? (dragons, nukies and such.)
         /// </summary>
         public bool Mob { get;  }
+        public bool IsDead { get;  }
         public bool Player_ghost { get;  }
         public bool Antagonist { get;  }
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -173,6 +173,9 @@
   save: false
   abstract: true
   components:
+  - type: WarpPoint # Rat - Better observe menu
+    follow: true
+    mob: true
   - type: Reactive
     groups:
       Acidic: [Touch]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -321,6 +321,9 @@
         clownedon: # Not 'creampied' bc I can already see Skyrat complaining about conflicts.
           True: {visible: true}
           False: {visible: false}
+  - type: WarpPoint # Rat - Better observe menu
+    follow: true
+    mob: true
   - type: StatusIcon
     bounds: -0.5,-0.5,0.5,0.5
   - type: HasJobIcons # Goobstation
@@ -507,9 +510,6 @@
   id: BaseMobSpeciesOrganic
   abstract: true
   components:
-  - type: WarpPoint # Rat - Better observe menu
-    follow: true
-    mob: true
   - type: Absorbable # Goobstation - changelings
   - type: Barotrauma
     damage:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -22,6 +22,9 @@
   parent: [BaseMob, MobDamageable, MobCombat, MobAtmosExposed, MobFlammable]
   abstract: true
   components:
+    - type: WarpPoint # Rat - Better observe menu
+      follow: true
+      mob: true
     - type: ContentEye
     - type: CameraRecoil
     - type: Reactive


### PR DESCRIPTION

## About the PR

- Makes sections on the orbit be auto-expanded by default
- Adds back jobs to the orbit menu
- Adds non-organics to the orbit menu
- Adds the "Dead" section to the menu, corpses be located there

## Why / Balance

> Makes sections on the orbit be auto-expanded by default
- Was requested, and yeah i think its better
> Adds back jobs to the orbit menu
- Quite a few more people used this than i expected, so tis being added back. There were plans to give icons next to people's names but after looking at how to do it for 4+ hours i never want to code for ss14 again. The shitcode is real
> Adds non-organics to the orbit menu
- Bug bad, didn't catch this one
> Adds the "Dead" section to the menu, corpses be located there
- Tbh shoulda been in the original, better to tell who's dead and who isn't now

## Media

How the menu now looks:

<img width="1600" height="858" alt="image" src="https://github.com/user-attachments/assets/877a5b71-78c8-4a29-9552-46c8ef6825c1" />

The new dead section (does not appear if there aren't dead people, same as antags)

<img width="1600" height="858" alt="image" src="https://github.com/user-attachments/assets/000c39c5-42ea-4e2e-a56f-6498a38e1172" />

## Requirements
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Readded jobs next to people's names back to the ghost orbit menu.
- fix: Fixed non-organics not showing up under the alive section of the ghost orbit menu
