### PR TITLE
Shit on paincrit, Tider death part 1

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
+++ b/Content.Shared/_Shitmed/Surgery/Pain/Components/NerveSystemComponent.cs
@@ -73,7 +73,7 @@ public sealed partial class NerveSystemComponent : Component
     public TimeSpan NextCritScream;
 
     [DataField("painShockStun")]
-    public TimeSpan PainShockStunTime = TimeSpan.FromSeconds(2f);
+    public TimeSpan PainShockStunTime = TimeSpan.FromSeconds(0f);
 
     [DataField("organDamageStun")]
     public TimeSpan OrganDamageStunTime = TimeSpan.FromSeconds(12f);
@@ -249,9 +249,9 @@ public sealed partial class NerveSystemComponent : Component
         { PainThresholdTypes.Agony, 40 },
         // Just having 'PainFlinch' is lame, people scream for a few seconds before passing out / getting pain shocked, so I added agony.
         // A lot of screams (individual pain screams poll), for the funnies.
-        { PainThresholdTypes.PainShock, 65 }, // real
+        { PainThresholdTypes.PainShock, 95 }, // real
         // usually appears after an explosion. or some ultra big damage output thing, you might survive, and most importantly, you will fall down in pain.
         // :troll:
-        { PainThresholdTypes.PainShockAndAgony, 85 },
+        { PainThresholdTypes.PainShockAndAgony, 180 },
     };
 }


### PR DESCRIPTION
Assistants become passengers. Why? You'll see.
Also balancing paincrit to be more fun.

also paincrit becomes less obnoxious during gunfights by being higher in threshold.