### PR TITLE
SUPER TRVTHNVKE BVLVNCE PR

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -123,7 +123,7 @@
       types:
         Piercing: 60 #Ratbite balance
         Structural: 15
-      armorPenetration: 0.25 # Ratbite - Did you know? Slug pen armor plate yes? Woooow. -Ducks
+      armorPenetration: 0.10 # Ratbite - Did you know? Slug pen armor plate yes? Woooow. -Ducks
 
 
 - type: entity
@@ -139,7 +139,6 @@
     damage:
       types:
         Blunt: 7.5
-        Airloss: 7.5 # Ratbite - Knock the wind outta 'em
   - type: StaminaDamageOnCollide
     damage: 60 # Goob edit
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -123,6 +123,7 @@
       types:
         Piercing: 60 #Ratbite balance
         Structural: 15
+      armorPenetration: 0.4 # Ratbite - Did you know? Slug pen armor plate yes? Woooow. -Ducks
 
 
 - type: entity
@@ -137,7 +138,7 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 20 #Ratbite balance
+        Blunt: 10
   - type: StaminaDamageOnCollide
     damage: 60 # Goob edit
 
@@ -153,8 +154,9 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 15 #Ratbite balance
-        Structural: 15
+        Piercing: 10 # Ratbite - TRVTHNVKE buckshit shitgun meta
+        Structural: 5 # Ratbite - they'll bleed out anyways from the pierce before you whine
+      armorPenetration: -0.4 # Ratbite - Body armor does what it's >>>explicitly designed to<<< against buckshot.
 
 
 - type: entity
@@ -164,8 +166,8 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgun
-    count: 10 #Ratbite balance
-    spread: 15
+    count: 9 # Ratbite - 10*9=90 + bloodloss DOT it's FINEEE
+    spread: 10 # Ratbite - tighten up the spread doe
 
 - type: entity
   id: PelletShotgunIncendiary
@@ -329,8 +331,9 @@
   - type: Projectile
     damage:
       types:
-        Radiation: 8 #Ratbite balance
-        Piercing: 8 #Ratbite balance
+        Radiation: 5 # Ratbite - Lingering radiation from DU fragments
+        Piercing: 10 # Ratbite
+      armorPenetration: 0.8 # Ratbite - Who knew depleted uranium was good at piercing armor?
 
 - type: entity
   id: PelletShotgunUraniumSpread
@@ -339,7 +342,7 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgunUranium
-    count: 5
+    count: 5 # 15*5=75 with tight spread and good AP
     spread: 6
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -123,7 +123,7 @@
       types:
         Piercing: 60 #Ratbite balance
         Structural: 15
-      armorPenetration: 0.4 # Ratbite - Did you know? Slug pen armor plate yes? Woooow. -Ducks
+      armorPenetration: 0.25 # Ratbite - Did you know? Slug pen armor plate yes? Woooow. -Ducks
 
 
 - type: entity
@@ -138,7 +138,8 @@
   - type: Projectile
     damage:
       types:
-        Blunt: 10
+        Blunt: 7.5
+        Airloss: 12.5
   - type: StaminaDamageOnCollide
     damage: 60 # Goob edit
 
@@ -333,7 +334,7 @@
       types:
         Radiation: 5 # Ratbite - Lingering radiation from DU fragments
         Piercing: 10 # Ratbite
-      armorPenetration: 0.8 # Ratbite - Who knew depleted uranium was good at piercing armor?
+      armorPenetration: 0.4 # Ratbite - Who knew depleted uranium was good at piercing armor?
 
 - type: entity
   id: PelletShotgunUraniumSpread
@@ -342,7 +343,7 @@
   components:
   - type: ProjectileSpread
     proto: PelletShotgunUranium
-    count: 5 # 15*5=75 with tight spread and good AP
+    count: 5 # 15*5=75 with tight spread and okay AP
     spread: 6
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -154,7 +154,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 10 # Ratbite - TRVTHNVKE buckshit shitgun meta
+        Piercing: 12 # Ratbite - TRVTHNVKE buckshit shitgun meta
         Structural: 5 # Ratbite - they'll bleed out anyways from the pierce before you whine
       armorPenetration: -0.4 # Ratbite - Body armor does what it's >>>explicitly designed to<<< against buckshot.
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -139,7 +139,7 @@
     damage:
       types:
         Blunt: 7.5
-        Airloss: 12.5
+        Airloss: 7.5 # Ratbite - Knock the wind outta 'em
   - type: StaminaDamageOnCollide
     damage: 60 # Goob edit
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -333,7 +333,7 @@
       types:
         Radiation: 5 # Ratbite - Lingering radiation from DU fragments
         Piercing: 10 # Ratbite
-      armorPenetration: 0.4 # Ratbite - Who knew depleted uranium was good at piercing armor?
+      armorPenetration: 0.3 # Ratbite - Who knew depleted uranium was good at piercing armor?
 
 - type: entity
   id: PelletShotgunUraniumSpread


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Buckshot was put back in the retirement home and no longer has 150 DAMAGE PER SHELL. Slugs remembered that they're good at penetrating armor. DU shells remembered that they shear through armor. Beanbags remembered they're supposed to be non lethal.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Death to the shitgun meta. Death to buckshot doing absurd damage even if you have armor on. Retvrn to slugs.

<details> <summary>Full list of values</summary>

Buckshot:
- 15 Pierce, 15 Struct -> 10 Pierce, 5 Struct per pellet.
- 10 Pellets -> 9 Pellets to match #00 Buckshot.
- Spread tightened.
- Significantly worse against armor. (40% Armor Weakness)

Slugs:
- Given 25% AP. Rejoice.

Uranium Buckshot:
- 8 Rad/Pierce -> 5 Rad, 10 Pierce.
- 40% AP per pellet.
- Pellet count is still 5, for a max of 75 DMG per round if all pellets hit.

Beanbags:
- Damage spread adjusted to 7.5 blunt/7.5 airloss for 15 total. Who's idea was it to make the *non-lethal* shell kill in 5?
</details>

## Technical details
<!-- Summary of code changes for easier review. -->
Comments left where files touched, except where the changes resulted in a revert to upstream values.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have heavily considered metagrudging Bevverius Ratbites Evilsqueaks for shit balancing.  
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Buckshot nerfed, but spread lowered.
- tweak: Slugs are now better at penetrating armor
- tweak: DU Buckshot made more accurate to actual DU munitions.
- tweak: Beanbags now less lethal as they should be.