### PR TITLE
Nerfed the pierce resistance on civillian head of staff hardsuits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -704,7 +704,7 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.4 #Ratbite
+        Piercing: 0.6 #Ratbite
         Heat: 0.4
         Radiation: 0.0
         Caustic: 0.7
@@ -748,7 +748,7 @@
       coefficients:
         Blunt: 0.8
         Slash: 0.8
-        Piercing: 0.4 #Ratbite
+        Piercing: 0.6 #Ratbite
         Heat: 0.4
         Caustic: 0.1
   - type: ZombificationResistance
@@ -783,7 +783,7 @@
       coefficients: #Goob - Modsuits all but pierce
         Blunt: 0.65
         Slash: 0.85
-        Piercing: 0.4 #Ratbite
+        Piercing: 0.6 #Ratbite
         Heat: 0.4
         Shock: 0.85
         Radiation: 0.05


### PR DESCRIPTION
Lowered the pierce resistance on the Chief Engineer, Research Director and Chief Medical Officer hardsuits from 60% to 40%

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- I changed the pierce resistance on the civillian head of staff hardsuits from 60% to 40% -->

## Why / Balance
<!-- Antags can no longer take advantage of the security level pierce resistance inside easily broken into lockers in their respective departments -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Pierce resistance on CMO, CE, and RD hardsuits changed from 60% to 40%-->
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
