### PR TITLE
perma prisoners get clumsy because they suck

### DIFF
--- a/Resources/Prototypes/_BRatbite/Roles/Jobs/Civilian/prisoner.yml
+++ b/Resources/Prototypes/_BRatbite/Roles/Jobs/Civilian/prisoner.yml
@@ -8,6 +8,19 @@
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security
   canBeAntag: false
+  special: #mald perma prisoner change
+  - !type:AddComponentSpecial 
+    components:
+    - type: Clumsy
+      gunShootFailDamage:
+        types: #literally just picked semi random valus. i tested this once and tweaked it.
+          Blunt: 5
+          Piercing: 4
+        groups:
+          Burn: 3
+      catchingFailDamage:
+        types:
+          Blunt: 1
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
gives permas clumsy

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
gave perma prisoners the clumsy trait.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There aren't enough measures inplace to prevent perma prisoners from taking shotguns and one tapping everyone (shotgun meta) so this just makes it much harder for them to use guns (they can still shoot it just has a chance to blow up in theier faces) this doesn't prevent them from fighting just makes them have to plan out their chuddery instead of just ward locker then armory on 6 pop
## Technical details
<!-- Summary of code changes for easier review. -->
copy and pasted clown clumsy trait into prisoner job spot.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: clumsy trait for permas.
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
