### PR TITLE
Unfuck bevvs shit

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -202,7 +202,6 @@
     - id: Changeling
     - id: SleeperAgents
     - id: ChangelingMidround
-    - id: SleeperAgents
     - id: HereticMidround
 
 # Ratbite Over
@@ -470,7 +469,7 @@
   - type: StationEvent
     weight: 3 # Goobstation - was 6
     duration: null
-    earliestStart: 30 # Goobstation - was 45
+    earliestStart: 25 # Ratbite - was 30, 25 is about our midpop during weekdays
     #reoccurrenceDelay: 20 # Goobstation - no longer needed
     maxOccurrences: 1 # Goobstation
     minimumPlayers: 30
@@ -483,7 +482,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 300
+    chaosScore: 500 # Ratbite - 900 was a bit much, though still a decent threat that summons more threats so 500 it is
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
     # Goobstation start

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -185,7 +185,7 @@
     children:
     - id: SlasherSpawn
  #   - id: XenomorphsInfestation
- #   - id: SleeperAgents
+    - id: SleeperAgents
  #   - id: ChangelingMidround Got annoying, moved to susrat
     - id: NinjaSpawn
     - id: DerelictCyborgSpawn # RB, This shit is annoying, antag, not normal ghost role.
@@ -202,6 +202,7 @@
     - id: Changeling
     - id: SleeperAgents
     - id: ChangelingMidround
+    - id: SleeperAgents
     - id: HereticMidround
 
 # Ratbite Over
@@ -472,7 +473,7 @@
     earliestStart: 30 # Goobstation - was 45
     #reoccurrenceDelay: 20 # Goobstation - no longer needed
     maxOccurrences: 1 # Goobstation
-    minimumPlayers: 35
+    minimumPlayers: 30
     chaos: # Goobstation
       Hostile: 20
       Friend: 20
@@ -482,7 +483,7 @@
     eventType: HostilesSpawn # Goobstation
   # Goobstation
   - type: GameRule
-    chaosScore: 900 # Ratbite antag cut
+    chaosScore: 300
   - type: SpaceSpawnRule
   - type: AntagLoadProfileRule
     # Goobstation start

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -33,7 +33,7 @@
       Death: 100
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 1000 # Ratbite antag cut
+    chaosScore: 400
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -41,7 +41,7 @@
     - prefRoles: [ Traitor ]
       min: 1
       max: 2
-      playerRatio: 15
+      playerRatio: 10
       blacklist:
         components:
         - AntagImmune
@@ -61,7 +61,7 @@
   - type: StationEvent
     earliestStart: 20
     weight: 4
-    minimumPlayers: 30 # Ratbite antag cut
+    minimumPlayers: 15
     maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
@@ -74,16 +74,16 @@
       Death: 150
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 1800 # Ratbite antag cut
+    chaosScore: 600
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
-      min: 0
+      min: 1
       max: 2
-      playerRatio: 20
+      playerRatio: 10
       blacklist:
         components:
         - CommandStaff
@@ -117,7 +117,7 @@
       Death: 200
     eventType: HostilesSpawn
   - type: GameRule
-    chaosScore: 1500 # Ratbite antag cut
+    chaosScore: 500
   - type: AlertLevelInterceptionRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn
@@ -125,7 +125,7 @@
     definitions:
     - prefRoles: [ Heretic ]
       max: 2
-      min: 0
+      min: 1
       playerRatio: 15
       blacklist:
         components:

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -61,7 +61,7 @@
   - type: StationEvent
     earliestStart: 20
     weight: 4
-    minimumPlayers: 15
+    minimumPlayers: 20 # Ratbite - We don't hit 30 pop unless it's the weekend or a real good day. Get a fucking grip.
     maxOccurrences: 1
     startAnnouncement: station-event-communication-interception
     startAudio:
@@ -83,7 +83,7 @@
     - prefRoles: [ Changeling ]
       min: 1
       max: 2
-      playerRatio: 10
+      playerRatio: 20
       blacklist:
         components:
         - CommandStaff
@@ -137,6 +137,9 @@
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       mindRoles:
       - MindRoleHeretic
+      components: # Ratbite - Why the fuck didn't midround heretics have WeakToHoly and CanEnchant?
+      - type: WeakToHoly
+      - type: CanEnchant
   - type: Tag
     tags:
       - MidroundAntag

--- a/Resources/Prototypes/_Goobstation/GameRules/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/midround.yml
@@ -132,7 +132,7 @@
         - CommandStaff
         - AntagImmune
         - BibleUser
-      startingGear: Heretictmidround
+      startingGear: HereticMidround
       lateJoinAdditional: true
       jobBlacklist: [ Chaplain ] # GOOBSTATION
       mindRoles:

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -36,7 +36,7 @@
     - prefRoles: [ Heretic ]
       max: 3
       playerRatio: 15
-      chaosScore: 500 # ratbite antag cut
+      chaosScore: 250
       lateJoinAdditional: true
       jobBlacklist: [ Chaplain, ] # GOOBSTATION
       blacklist:

--- a/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Roles/Antags/heretic.yml
@@ -29,7 +29,7 @@
   guides: [ Heretics ]
 
 - type: startingGear
-  id: Heretictmidround
+  id: HereticMidround
   storage:
     back:
     - Inkofimaginination


### PR DESCRIPTION
Edit: _Partially_ Reverts RatBite-Station-14/Rat_Bite_Station_14#337, and fixes issues with midround heretics.

Not only did this essentially turn Susrat into Nothing Ever Happens, this *also* ends up fucking with other gamemodes because you changed the chaosscore of the events, something COMPLETELY UNUSED BY SUSRAT AND SQUEAKRAT.

NEITHER of Susrat and Squeakrat are actual GameDirector gamemodes, and the player req/player ratios are out of wack for what our actual pop looks like during the week.

Do better, read the (very little) documentation around gamemodes, and maybe actually merge #315 so changes to chaosscore might mean something.
<img width="640" height="681" alt="image" src="https://github.com/user-attachments/assets/0e36656e-324e-42cd-970c-a3b76e355492" />
