### PR TITLE
Add minshielded lockers

### DIFF
--- a/Content.Goobstation.Server/Destructible/Thresholds/Behaviors/RadioBehavior.cs
+++ b/Content.Goobstation.Server/Destructible/Thresholds/Behaviors/RadioBehavior.cs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Perstronzio Desantis <44839463+PropenzioLavandino@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace Content.Goobstation.Server.Destructible.Thresholds.Behaviors;
+using Content.Server.Destructible.Thresholds.Behaviors;
+using Content.Server.Radio.EntitySystems;
+using Content.Server.Destructible;
+using Content.Shared.IdentityManagement;
+
+/// <summary>
+/// Sends a message to a selected radio channel
+/// </summary>
+[DataDefinition]
+public sealed partial class RadioBehavior : IThresholdBehavior
+{
+    /// <summary>
+    /// Locale id of the radio message.
+    /// </summary>
+    [DataField("radioMessage", required: true)]
+    public string radioMessage;
+
+    /// <summary>
+    /// Which radio channel to show
+    /// </summary>
+    [DataField("radioChannel", required: true)]
+    public string radioChannel;
+
+    public void Execute(EntityUid uid, DestructibleSystem system, EntityUid? cause = null)
+    {
+	var radio = system.EntityManager.System<RadioSystem>();
+	 radio.SendRadioMessage(uid,
+				Loc.GetString(radioMessage, ("entityName", Identity.Name(uid, system.EntityManager))),
+				radioChannel,
+				uid);
+    }
+}

--- a/Content.Shared/Access/Components/AccessReaderComponent.cs
+++ b/Content.Shared/Access/Components/AccessReaderComponent.cs
@@ -162,6 +162,12 @@ public sealed partial class AccessReaderComponent : Component
     /// </summary>
     [DataField]
     public bool BreakOnAccessBreaker = true;
+
+    /// <summary>
+    /// Wheter or not this needs mindshield to access
+    /// </summary>
+    [DataField]
+    public bool NeedsMindshield = false;
 }
 
 [DataDefinition, Serializable, NetSerializable]

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -108,6 +108,7 @@ using Robust.Shared.Collections;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared.Mindshield.Components;
 
 namespace Content.Shared.Access.Systems;
 
@@ -210,6 +211,10 @@ public sealed class AccessReaderSystem : EntitySystem
         var accessSources = FindPotentialAccessItems(user);
         var access = FindAccessTags(user, accessSources);
         FindStationRecordKeys(user, out var stationKeys, accessSources);
+
+	if (reader.NeedsMindshield && !HasComp<MindShieldComponent>(user)) {
+	    return false;
+	}
 
         if (!IsAllowed(access, stationKeys, target, reader))
             return false;

--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -100,6 +100,7 @@ using Content.Shared.UserInterface;
 using Content.Shared.Verbs;
 using Content.Shared.Wires;
 using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Mindshield.Components;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Utility;
@@ -362,6 +363,13 @@ public sealed class LockSystem : EntitySystem
         // Not having an AccessComponent means you get free access. woo!
         if (!Resolve(uid, ref reader, false))
             return true;
+		
+	if (reader.NeedsMindshield && !HasComp<MindShieldComponent>(user)) {
+	    if (!quiet) {
+		_sharedPopupSystem.PopupClient(Loc.GetString("lock-comp-no-mindshield", ("entityName", Identity.Name(uid, EntityManager))), uid, user);
+	    }
+	    return false;
+	}
 
         if (_accessReader.IsAllowed(user, uid, reader))
             return true;

--- a/Resources/Locale/en-US/lock/lock-component.ftl
+++ b/Resources/Locale/en-US/lock/lock-component.ftl
@@ -10,7 +10,7 @@ lock-comp-on-examined-is-unlocked = The {$entityName} seems to be unlocked.
 lock-comp-do-lock-success = You lock the {$entityName}.
 lock-comp-do-unlock-success = You unlock the {$entityName}.
 lock-comp-has-user-access-fail = Access denied.
-lock-comp-no-mindshield = Nanotrasen forbids you from opening the {$entityName}.
+lock-comp-no-mindshield = Access denied: You are missing a mindshield to unlock the {$entityName}.
 lock-comp-generic-fail = {CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} locked.
 
 ## ToggleLockVerb

--- a/Resources/Locale/en-US/lock/lock-component.ftl
+++ b/Resources/Locale/en-US/lock/lock-component.ftl
@@ -10,6 +10,7 @@ lock-comp-on-examined-is-unlocked = The {$entityName} seems to be unlocked.
 lock-comp-do-lock-success = You lock the {$entityName}.
 lock-comp-do-unlock-success = You unlock the {$entityName}.
 lock-comp-has-user-access-fail = Access denied.
+lock-comp-no-mindshield = Nanotrasen forbids you from opening the {$entityName}.
 lock-comp-generic-fail = {CAPITALIZE(SUBJECT($target))} {CONJUGATE-BE($target)} locked.
 
 ## ToggleLockVerb

--- a/Resources/Locale/en-US/lockers/locker.ftl
+++ b/Resources/Locale/en-US/lockers/locker.ftl
@@ -1,0 +1,1 @@
+locker-mindshield-destroy = The {$entityName} has been destroyed!

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -109,5 +109,14 @@
   abstract: true
   components:
     - type: Destructible
-      thresholds: []
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 2000
+          behaviors:
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+            - !type:RadioBehavior
+              radioMessage: "locker-mindshield-destroy"
+              radioChannel: "Security"
   

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -102,21 +102,3 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
-
-- type: entity
-  id: LockerMindshielded
-  parent: LockerBaseSecure
-  abstract: true
-  components:
-    - type: Destructible
-      thresholds:
-        - trigger:
-            !type:DamageTrigger
-            damage: 2000
-          behaviors:
-            - !type:DoActsBehavior
-              acts: ["Destruction"]
-            - !type:RadioBehavior
-              radioMessage: "locker-mindshield-destroy"
-              radioChannel: "Security"
-  

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -102,3 +102,12 @@
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
+
+- type: entity
+  id: LockerMindshielded
+  parent: LockerBaseSecure
+  abstract: true
+  components:
+    - type: Destructible
+      thresholds: []
+  

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -398,7 +398,7 @@
 # Brigmedic
 - type: entity
   id: LockerBrigmedic
-  parent: LockerMindshielded
+  parent: LockerBaseSecure
   name: brigmedic locker
   components:
   - type: Appearance
@@ -408,12 +408,11 @@
     stateDoorClosed: brigmedic_door
   - type: AccessReader
     access: [["Security"]] # goob edit
-    needsMindshield: true
 
 # Security Officer
 - type: entity
   id: LockerSecurity
-  parent: LockerMindshielded
+  parent: LockerBaseSecure
   name: security officer's locker
   components:
   - type: Appearance
@@ -423,7 +422,6 @@
     stateDoorClosed: sec_door
   - type: AccessReader
     access: [["Security"]]
-    needsMindshield: true
 
 - type: entity
   id: GunSafe
@@ -571,7 +569,6 @@
   components:
   - type: AccessReader
     access: [["Detective"]]
-    needsMindshield: true
 
 - type: entity
   id: LockerEvidence

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -107,7 +107,7 @@
 # Command
 - type: entity
   id: LockerCaptain
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: captain's locker
   components:
   - type: Appearance
@@ -117,10 +117,11 @@
     stateDoorClosed: cap_door
   - type: AccessReader
     access: [["Captain"]]
+    needsMindshield: true
 
 - type: entity
   id: LockerHeadOfPersonnel
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: head of personnel's locker
   components:
   - type: Appearance
@@ -130,11 +131,12 @@
     stateDoorClosed: hop_door
   - type: AccessReader
     access: [["HeadOfPersonnel"]]
+    needsMindshield: true
 
 # CE
 - type: entity
   id: LockerChiefEngineer
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: chief engineer's locker
   components:
   - type: Appearance
@@ -144,6 +146,7 @@
     stateDoorClosed: ce_door
   - type: AccessReader
     access: [ [ "ChiefEngineer" ] ]
+    needsMindshield: true
 
 # Electrical supplies
 - type: entity
@@ -323,7 +326,7 @@
 # CMO
 - type: entity
   id: LockerChiefMedicalOfficer
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: chief medical officer's locker
   components:
   - type: Appearance
@@ -333,6 +336,7 @@
     stateDoorClosed: cmo_door
   - type: AccessReader
     access: [ [ "ChiefMedicalOfficer" ] ]
+    needsMindshield: true
 
 # Science
 - type: entity
@@ -364,7 +368,7 @@
 # HoS
 - type: entity
   id: LockerHeadOfSecurity
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: head of security's locker
   components:
   - type: Appearance
@@ -374,11 +378,12 @@
     stateDoorClosed: hos_door
   - type: AccessReader
     access: [["HeadOfSecurity"]]
+    needsMindshield: true
 
 # Warden
 - type: entity
   id: LockerWarden
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: warden's locker
   components:
   - type: Appearance
@@ -388,11 +393,12 @@
     stateDoorClosed: warden_door
   - type: AccessReader
     access: [["Armory"]]
+    needsMindshield: true
 
 # Brigmedic
 - type: entity
   id: LockerBrigmedic
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: brigmedic locker
   components:
   - type: Appearance
@@ -402,11 +408,12 @@
     stateDoorClosed: brigmedic_door
   - type: AccessReader
     access: [["Security"]] # goob edit
+    needsMindshield: true
 
 # Security Officer
 - type: entity
   id: LockerSecurity
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   name: security officer's locker
   components:
   - type: Appearance
@@ -416,6 +423,7 @@
     stateDoorClosed: sec_door
   - type: AccessReader
     access: [["Security"]]
+    needsMindshield: true
 
 - type: entity
   id: GunSafe
@@ -563,6 +571,7 @@
   components:
   - type: AccessReader
     access: [["Detective"]]
+    needsMindshield: true
 
 - type: entity
   id: LockerEvidence
@@ -649,11 +658,12 @@
 - type: entity
   id: LockerRepresentative
   name: representative locker
-  parent: LockerBaseSecure
+  parent: LockerMindshielded
   components:
   - type: Appearance
   - type: AccessReader
     access: [["Command"]]
+    needsMindshield: true
   - type: EntityStorageVisuals
     stateBaseClosed: hop
     stateDoorOpen: hop_open

--- a/Resources/Prototypes/_BRatbite/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Structures/Storage/Closets/Lockers/base_structurelockers.yml
@@ -1,0 +1,17 @@
+- type: entity
+  id: LockerMindshielded
+  parent: LockerBaseSecure
+  abstract: true
+  components:
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 900
+          behaviors:
+            - !type:DoActsBehavior
+              acts: ["Destruction"]
+            - !type:RadioBehavior
+              radioMessage: "locker-mindshield-destroy"
+              radioChannel: "Security"
+  


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This PR adds mindshielded lockers to heads.
Mindshield lockers function the same as regular lockers, but also check for mindshield before unlocking.
Also made them more resistant and made it send a message on security radio when destroyed.
## Why / Balance
When discussing on the discord about why people weren't playing heads, someone mentioned "Why play CE/CMO when you can just break into their lockers and take their gear. I have also seen a lot of people do that in general, which makes heads just a lesser version of regular jobs in the eyes of many people (Since they have a mindshield).
This also fixes the issue of the captain or hos forgetting to mindshield a head or security officer, since without the mindshield they cannot get into their locker.
Also many times when playing latejoin CMO or CE I found that my stuff had already been looted

## Media
<img width="419" height="154" alt="image" src="https://github.com/user-attachments/assets/3c903d13-b32c-4afa-9da9-a9958b3f209a" />
<img width="455" height="103" alt="image" src="https://github.com/user-attachments/assets/25088ddd-15fe-4703-8fa5-3ac82aa9b396" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Made heads of staff lockers more secure
