### PR TITLE
Add lone ops console

### DIFF
--- a/Resources/Locale/en-US/_BRatbite/communications/communications-console-component.ftl
+++ b/Resources/Locale/en-US/_BRatbite/communications/communications-console-component.ftl
@@ -1,0 +1,1 @@
+comms-console-announcement-title-loneops = Lone Nuclear Operative

--- a/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
+++ b/Resources/Maps/Shuttles/ShuttleEvent/striker.yml
@@ -1829,7 +1829,7 @@ entities:
       parent: 65
     - type: Physics
       canCollide: False
-- proto: SyndicateComputerComms
+- proto: LoneOpsComputerComms
   entities:
   - uid: 65
     components:

--- a/Resources/Prototypes/_BRatbite/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Structures/Machines/Computers/computers.yml
@@ -1,0 +1,8 @@
+- type: entity
+  parent: SyndicateComputerComms
+  id: LoneOpsComputerComms
+  name: Lone Operative Computer
+  description: A computer capable of remotely hacking into the station's communications systems. Using this to make an announcement will alert the station to your presence.
+  components:
+  - type: CommunicationsConsole
+    title: comms-console-announcement-title-loneops


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add a Lone Ops console to lone nuclear operatives

## Why / Balance
Sec usually starts arming the whole station when there is the lone operative, because they don't know that it's just one guy and not the complete nuclear operative event. I think this ruins the whole round and makes it round ending, even though lone op is not supposed to be a round ending antagonist. 
This makes it more clear, and hopefully sec/command will be less likely to arm everybody and more likely to actually engage with the threat.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="444" height="69" alt="image" src="https://github.com/user-attachments/assets/1ab0ac8d-a6d2-4bf5-a931-f9071b431243" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: A special console for lone ops
