### PR TITLE
Prevent cryostorage body removal when ssd or no mind

### DIFF
--- a/Content.Server/_BRatbite/Bed/Cryostorage/PreventCryostorageRemovalSystem.cs
+++ b/Content.Server/_BRatbite/Bed/Cryostorage/PreventCryostorageRemovalSystem.cs
@@ -1,0 +1,78 @@
+using Robust.Shared.Containers;
+
+using Content.Shared.Bed.Cryostorage;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Access.Systems;
+using Content.Shared.Verbs;
+using Content.Shared.Database;
+using Content.Shared.Mind;
+using Content.Shared.Popups;
+using Robust.Shared.Player;
+using Content.Shared.Mind.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.Utility;
+
+namespace Content.Server._BRatbite.Bed.Cryostorage;
+
+/// <summary>
+/// Prevents players from ejecting AFK people from the cryostorage if they don't have
+/// cryo access
+/// </summary>
+public sealed class PreventCryostorageRemovalSystem : EntitySystem
+{
+    [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
+    [Dependency] private readonly SharedContainerSystem _sharedContainerSystem = default!;
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerManager = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CryostorageComponent, GetVerbsEvent<AlternativeVerb>>(AddAlternativeVerbs);
+    }
+
+    private void AddAlternativeVerbs(Entity<CryostorageComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (_sharedContainerSystem.TryGetContainer(ent.Owner, ent.Comp.ContainerId, out var baseContainer))
+        {
+            if (baseContainer.ContainedEntities.Count > 0)
+            {
+                var user = args.User;
+                args.Verbs.Add(
+                new AlternativeVerb
+                {
+                    Text = Loc.GetString("container-verb-text-empty"),
+                    Category = VerbCategory.Eject,
+                    Priority = 1,
+                    Act = () =>
+                    {
+                        TryEjectBody(ent, user, baseContainer);
+                    }
+                }
+                );
+            }
+        }
+    }
+
+    private void TryEjectBody(Entity<CryostorageComponent> ent, EntityUid userId, BaseContainer container)
+    {
+        if (container.ContainedEntities.Count == 0)
+            return;
+        var cryodEntity = container.ContainedEntities[0];
+        var hasMind = _mind.TryGetMind(cryodEntity, out EntityUid mind, out var mindComponent);
+        var session = mindComponent?.UserId;
+        var hasActiveSession = session != null && _playerManager.ValidSessionId(session.Value);
+        if ((!hasMind || !hasActiveSession) && !_accessReader.IsAllowed(userId, ent))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("cryostorage-prevent-removal"), ent.Owner, userId);
+            return;
+        }
+
+        _adminLog.Add(LogType.Action, LogImpact.Low, $"{ToPrettyString(userId):player} emptied container {ToPrettyString(ent)}");
+        _sharedContainerSystem.EmptyContainer(container);
+    }
+}

--- a/Resources/Locale/en-US/_BRatbite/Bed/Cryostorage/prevent-cryostorage-removal.ftl
+++ b/Resources/Locale/en-US/_BRatbite/Bed/Cryostorage/prevent-cryostorage-removal.ftl
@@ -1,0 +1,1 @@
+cryostorage-prevent-removal = You are unable to unlock the cryogenic storage. You suddenly feel a sense of guilt rushing over you

--- a/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
+++ b/Resources/Prototypes/Entities/Structures/cryogenic_sleep_unit.yml
@@ -41,6 +41,7 @@
   - type: DragInsertContainer
     containerId: storage
     entryDelay: 2
+    useVerbs: false # Ratbite: use custom empty verb to prevent emptying when ssd
   - type: ExitContainerOnMove
     containerId: storage
   - type: PointLight


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Make people without cryo access unable to eject people from the cryostorage, but only if the cryo-ing player has left the server or has /ghosted.

## Why / Balance

Some people just camp the cryo unit until an important role cryod and then looted their corpse. If they want the items, they should at least be fighting before the person has left the server.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="706" height="170" alt="image" src="https://github.com/user-attachments/assets/142ec78e-91e3-4da3-b205-274105022982" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cryogenic units have gotten a new lock
