### PR TITLE
Combat trained trait

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -568,7 +568,8 @@ public sealed partial class GunSystem : SharedGunSystem
 
         var spread = component.CurrentAngle.Theta * random;
         var angle = new Angle(direction.Theta + component.CurrentAngle.Theta * random);
-        DebugTools.Assert(spread <= component.MaxAngleModified.Theta);
+        // Ratbite: There are debuffs to spread now, remove the assert
+        // DebugTools.Assert(spread <= component.MaxAngleModified.Theta);
         return angle;
     }
 

--- a/Content.Server/_BRatbite/Traits/ScaredOfGunsComponent.cs
+++ b/Content.Server/_BRatbite/Traits/ScaredOfGunsComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server._BRatbite.Traits;
+
+[RegisterComponent]
+public sealed partial class ScaredOfGunsComponent : Component
+{
+    [DataField]
+    public float MissShotChance = 0.20f;
+
+    [DataField]
+    public float DropGunChance = 0.10f;
+}

--- a/Content.Server/_BRatbite/Traits/ScaredOfGunsSystem.cs
+++ b/Content.Server/_BRatbite/Traits/ScaredOfGunsSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Popups;
+using Robust.Shared.Random;
+using Content.Shared.Hands.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Hands.EntitySystems;
+
+namespace Content.Server._BRatbite.Traits;
+
+public sealed partial class ScaredOfGunsSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<ScaredOfGunsComponent, ShotAttemptedEvent>(OnShotAttempted);
+    }
+
+    private void OnShotAttempted(Entity<ScaredOfGunsComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (_random.Prob(ent.Comp.DropGunChance) && TryComp<HandsComponent>(ent.Owner, out var handComp))
+        {
+            if (_handsSystem.TryDrop(new(ent.Owner, handComp)))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("gun-fail-drop-shoot"), ent.Owner, ent.Owner);
+                args.Cancel();
+                return;
+            }
+
+        }
+        if (_random.Prob(ent.Comp.MissShotChance))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("gun-fail-shoot"), ent.Owner, ent.Owner);
+            args.Cancel();
+            return;
+        }
+    }
+
+}

--- a/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
+++ b/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
@@ -1,0 +1,71 @@
+using Content.Shared.Popups;
+using Content.Goobstation.Common.Weapons.Ranged;
+using Content.Shared.Weapons.Ranged.Events;
+using Robust.Shared.Random;
+using Content.Shared.Hands.Components;
+using Content.Shared.Popups;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared._BRatbite.Weapons.Ranged;
+using Content.Shared.NukeOps;
+
+namespace Content.Server._BRatbite.Weapons.Ranged;
+
+public sealed partial class CombatTrainedSystem : EntitySystem
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<CombatUntrainedComponent, GetRecoilModifiersEvent>(OnRecoilModifiersEvent);
+        SubscribeLocalEvent<CombatUntrainedComponent, ShotAttemptedEvent>(OnShotAttempted);
+        SubscribeLocalEvent<CombatTrainedComponent, ComponentStartup>(OnInitializeComp);
+        SubscribeLocalEvent<CombatTrainedComponent, ComponentShutdown>(OnShutdownComp);
+        SubscribeLocalEvent<NukeOperativeComponent, ComponentStartup>(OnInitializeNukeOps);
+    }
+
+    private void OnInitializeNukeOps(Entity<NukeOperativeComponent> ent, ref ComponentStartup args)
+    {
+        // Add it like this to nukeops because there are a bunch of nuclear operative prototypes
+        // And I don't want to add them manually
+        _entityManager.RemoveComponent<CombatUntrainedComponent>(ent.Owner);
+        AddComp<CombatTrainedComponent>(ent.Owner);
+    }
+
+    private void OnInitializeComp(Entity<CombatTrainedComponent> ent, ref ComponentStartup args)
+    {
+        _entityManager.RemoveComponent<CombatUntrainedComponent>(ent.Owner);
+    }
+
+    private void OnShutdownComp(Entity<CombatTrainedComponent> ent, ref ComponentShutdown args)
+    {
+        AddComp<CombatUntrainedComponent>(ent.Owner);
+    }
+
+    private void OnRecoilModifiersEvent(Entity<CombatUntrainedComponent> ent, ref GetRecoilModifiersEvent args)
+    {
+        args.Modifier = (args.Modifier * ent.Comp.RecoilDebuff) + ent.Comp.FlatRecoilDebuff;
+    }
+
+    private void OnShotAttempted(Entity<CombatUntrainedComponent> ent, ref ShotAttemptedEvent args)
+    {
+        if (_random.Prob(ent.Comp.DropGunChance) && TryComp<HandsComponent>(ent.Owner, out var handComp))
+        {
+            if (_handsSystem.TryDrop(new(ent.Owner, handComp)))
+            {
+                _popupSystem.PopupEntity(Loc.GetString("gun-fail-drop-shoot"), ent.Owner, ent.Owner);
+                args.Cancel();
+                return;
+            }
+
+        }
+        if (_random.Prob(ent.Comp.MissShotChance))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("gun-fail-shoot"), ent.Owner, ent.Owner);
+            args.Cancel();
+            return;
+        }
+    }
+}

--- a/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
+++ b/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
@@ -1,10 +1,5 @@
-using Content.Shared.Popups;
 using Content.Goobstation.Common.Weapons.Ranged;
 using Content.Shared.Weapons.Ranged.Events;
-using Robust.Shared.Random;
-using Content.Shared.Hands.Components;
-using Content.Shared.Popups;
-using Content.Shared.Hands.EntitySystems;
 using Content.Shared._BRatbite.Weapons.Ranged;
 using Content.Shared.NukeOps;
 
@@ -12,15 +7,13 @@ namespace Content.Server._BRatbite.Weapons.Ranged;
 
 public sealed partial class CombatTrainedSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IEntityManager _entityManager = default!;
-    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
-    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+
 
     public override void Initialize()
     {
+        base.Initialize();
         SubscribeLocalEvent<CombatUntrainedComponent, GetRecoilModifiersEvent>(OnRecoilModifiersEvent);
-        SubscribeLocalEvent<CombatUntrainedComponent, ShotAttemptedEvent>(OnShotAttempted);
         SubscribeLocalEvent<CombatTrainedComponent, ComponentStartup>(OnInitializeComp);
         SubscribeLocalEvent<CombatTrainedComponent, ComponentShutdown>(OnShutdownComp);
         SubscribeLocalEvent<NukeOperativeComponent, ComponentStartup>(OnInitializeNukeOps);
@@ -49,23 +42,4 @@ public sealed partial class CombatTrainedSystem : EntitySystem
         args.Modifier = (args.Modifier * ent.Comp.RecoilDebuff) + ent.Comp.FlatRecoilDebuff;
     }
 
-    private void OnShotAttempted(Entity<CombatUntrainedComponent> ent, ref ShotAttemptedEvent args)
-    {
-        if (_random.Prob(ent.Comp.DropGunChance) && TryComp<HandsComponent>(ent.Owner, out var handComp))
-        {
-            if (_handsSystem.TryDrop(new(ent.Owner, handComp)))
-            {
-                _popupSystem.PopupEntity(Loc.GetString("gun-fail-drop-shoot"), ent.Owner, ent.Owner);
-                args.Cancel();
-                return;
-            }
-
-        }
-        if (_random.Prob(ent.Comp.MissShotChance))
-        {
-            _popupSystem.PopupEntity(Loc.GetString("gun-fail-shoot"), ent.Owner, ent.Owner);
-            args.Cancel();
-            return;
-        }
-    }
 }

--- a/Content.Shared/_BRatbite/Interact/AddComponentOnInteractComponent.cs
+++ b/Content.Shared/_BRatbite/Interact/AddComponentOnInteractComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Prototypes;
+namespace Content.Shared._BRatbite.Interact;
+
+[RegisterComponent]
+public sealed partial class AddComponentsOnInteractComponent : Component
+{
+    [DataField]
+    public ComponentRegistry Components;
+
+    [DataField]
+    public string? PopupText;
+}

--- a/Content.Shared/_BRatbite/Interact/AddComponentsOnInteractSystem.cs
+++ b/Content.Shared/_BRatbite/Interact/AddComponentsOnInteractSystem.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Hands;
+using Content.Shared.Popups;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction;
+using Content.Shared.Interaction.Events;
+
+namespace Content.Shared._BRatbite.Interact;
+
+public sealed partial class AddComponentsOnInteractSystem : EntitySystem
+{
+    [Dependency] private IEntityManager _entityManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AddComponentsOnInteractComponent, UseInHandEvent>(OnInteractHand);
+    }
+
+    private void OnInteractHand(Entity<AddComponentsOnInteractComponent> ent, ref UseInHandEvent args)
+    {
+        _entityManager.AddComponents(args.User, ent.Comp.Components);
+        if (ent.Comp.PopupText != null)
+            _popupSystem.PopupClient(Loc.GetString(ent.Comp.PopupText), args.User, args.User);
+    }
+}

--- a/Content.Shared/_BRatbite/Weapons/Ranged/CombatTrainedComponent.cs
+++ b/Content.Shared/_BRatbite/Weapons/Ranged/CombatTrainedComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.Weapons.Ranged;
+
+[RegisterComponent]
+public sealed partial class CombatTrainedComponent : Component
+{ }

--- a/Content.Shared/_BRatbite/Weapons/Ranged/UntrainedComponent.cs
+++ b/Content.Shared/_BRatbite/Weapons/Ranged/UntrainedComponent.cs
@@ -1,0 +1,19 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.Weapons.Ranged;
+
+[RegisterComponent]
+public sealed partial class CombatUntrainedComponent : Component
+{
+    [DataField]
+    public float RecoilDebuff = 2f;
+
+    [DataField]
+    public float FlatRecoilDebuff = 5f;
+
+    [DataField]
+    public float MissShotChance = 0.05f;
+
+    [DataField]
+    public float DropGunChance = 0.01f;
+}

--- a/Resources/Locale/en-US/_BRatbite/books/books.ftl
+++ b/Resources/Locale/en-US/_BRatbite/books/books.ftl
@@ -1,0 +1,3 @@
+book-combat-training-name = How to Robust 101
+book-combat-training-desc = A guide made by NT aimed to train cadets in the intricate art of combat
+book-combat-training-success = You feel yourself becoming more robust

--- a/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
+++ b/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
@@ -55,5 +55,7 @@ trait-atheist-desc = You do not believe in Gods
 
 trait-combat-trained-name = Combat Trained
 trait-combat-trained-desc = You are trained in combat and able to shoot guns accurately. Security Personnel are combat trained by default.
+trait-scared-of-guns-name = Scared of guns
+trait-scared-of-guns-desc = You are scared of guns and may drop them accidentally when shooting.
 gun-fail-drop-shoot = You accidentally drop your gun!
 gun-fail-shoot = Your hands tremble and you were unable to shoot.

--- a/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
+++ b/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
@@ -52,3 +52,8 @@ trait-lord-perstronzios-rage-desc =
 
 trait-atheist-name = Atheist
 trait-atheist-desc = You do not believe in Gods
+
+trait-combat-trained-name = Combat Trained
+trait-combat-trained-desc = You are trained in combat and able to shoot guns accurately. Security Personnel are combat trained by default.
+gun-fail-drop-shoot = You accidentally drop your gun!
+gun-fail-shoot = Your hands tremble and you were unable to shoot.

--- a/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_security.yml
@@ -114,3 +114,13 @@
   cost: 250
   category: cargoproduct-category-name-security
   group: market
+
+- type: cargoProduct
+  id: SecurityCombatTrainingBook
+  icon:
+    sprite: Clothing/Hands/Gloves/Boxing/boxinggreen.rsi
+    state: icon
+  product: CrateCombatTrainingBook
+  cost: 1000
+  category: cargoproduct-category-name-security
+  group: market

--- a/Resources/Prototypes/Catalog/Fills/Crates/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/security.yml
@@ -136,3 +136,13 @@
       amount: 1
     - id: Bola # replace with 4 e-bolas when added
       amount: 4
+- type: entity
+  parent: CrateSecgear
+  id: CrateCombatTrainingBook
+  name: "How to robust 101"
+  description: "A guide made by NT aimed to train cadets in the intricate art of combat"
+  components:
+  - type: StorageFill
+    contents:
+    - id: BookCombatTraining
+      amount: 1

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -184,6 +184,9 @@
       - id: ClothingBeltCorporateJudoFilled
         weight: 0.5
     # Goobstation - Martial Arts - end
+    # Ratbite: robust 101
+    - id: BookCombatTraining
+      prob: 0.25
 
 - type: entity
   id: LockerBrigmedicFilled

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -126,6 +126,9 @@
   - LanguageKnowledge
   - ForeignerTrait
   # Einstein Engines - Language end
+  # ratbite
+  - CombatTrained
+  - CombatUntrained
   blacklist:
     components:
     - AttachedClothing # helmets, which are part of the suit

--- a/Resources/Prototypes/Entities/Mobs/Player/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/human.yml
@@ -236,3 +236,4 @@
     follow: true
     mob: true
     antagonist: true
+  - type: CombatTrained

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -596,7 +596,7 @@
   - type: CombatUntrained
     recoilDebuff: 2
     flatRecoilDebuff: 5.0
-    missShotChange: 0.05
+    missShotChance: 0.05
     dropGunChance: 0.01
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -592,6 +592,12 @@
     - Bacterial
     - Parasite
   # </Goobstation>
+  # Ratbite: All species are combat untrained by default, unless they are given the trained component
+  - type: CombatUntrained
+    recoilDebuff: 2
+    flatRecoilDebuff: 5.0
+    missShotChange: 0.05
+    dropGunChance: 0.01
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/cburn.yml
@@ -29,6 +29,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear # Goobstation - Start - Sol
   id: CBURNGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/deathsquad.yml
@@ -34,6 +34,7 @@
   - !type:AddComponentSpecial
     components:
     - type: DeathSquadMember # Goobstation
+    - type: CombatTrained # ratbite
 
   # Goobstation Start - I basically re-did all of deathsquads stuff so. - Sol
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -134,6 +134,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained
 
 - type: startingGear
   id: ERTLeaderGear
@@ -217,6 +220,7 @@
     - type: BibleUser #Lets them heal with bibles
     - type: CurseImmune # Goobstation - Wraith
     - type: CanEnchant #GoobStation
+    - type: CombatTrained # ratbite
   - !type:AddImplantSpecial
      implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
 
@@ -316,6 +320,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: ERTEngineerGear
@@ -404,6 +411,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: ERTSecurityGear
@@ -511,6 +521,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: ERTMedicalGear
@@ -597,6 +610,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: ERTJanitorGear

--- a/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/official.yml
@@ -58,6 +58,9 @@
   special: # Goobstation
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant, FreedomImplant, BluespaceLifelineImplant, RadioImplantCentcomm, NutrimentPumpImplant, StypticStimulatorImplant, DeathRattleImplantCentcomm ]
+  - !type:AddComponentSpecial
+    components:
+      - type: CombatTrained # ratbite
 
 - type: startingGear # Goobstation - Start - SolsticeOfTheWinter
   id: CentcomGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -184,6 +184,7 @@
       - type: CommandStaff
       - type: Condemned # Goobstation - Nanotrasen owns your soul pal.
         soulOwnedNotDevil: true
+      - type: CombatTrained # Ratbite
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -100,6 +100,7 @@
   - !type:AddComponentSpecial # goobstation
     components:
       - type: SecurityStaff
+      - type: CombatTrained
 
 - type: startingGear
   id: DetectiveGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -184,6 +184,7 @@
     components:
       - type: CommandStaff
       - type: SecurityStaff # goobstation
+      - type: CombatTrained
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -133,6 +133,7 @@
   - !type:AddComponentSpecial # goobstation
     components:
       - type: SecurityStaff
+      - type: CombatTrained
 
 - type: startingGear
   id: SecurityCadetGear

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -121,6 +121,7 @@
   - !type:AddComponentSpecial # goobstation
     components:
       - type: SecurityStaff
+      - type: CombatTrained
 
 - type: startingGear
   id: SecurityOfficerGear

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -170,6 +170,7 @@
   - !type:AddComponentSpecial # goobstation
     components:
       - type: SecurityStaff
+      - type: CombatTrained
 
 - type: startingGear
   id: WardenGear

--- a/Resources/Prototypes/_BRatbite/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Objects/Misc/books.yml
@@ -1,0 +1,53 @@
+- type: entity
+  parent: BaseItem
+  id: BookCombatTraining
+  name: "How to Robust 101"
+  description: "A guide made by NT aimed to train cadets in the intricate art of combat"
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_base
+      color: "#8b1a1a"
+    - state: decor_wingette
+      color: "#c8a800"
+    - state: icon_apple
+    - state: icon_corner
+      color: gold
+  - type: Tag
+    tags:
+    - Book
+    - Paper # Goobstation - Moth food
+  - type: MeleeWeapon
+    soundHit:
+      collection: Punch
+    damage:
+      types:
+        Blunt: 1
+  - type: DamageOtherOnHit
+    damage:
+      types:
+  # Goobstation Edit Start - Moth food
+  - type: Food
+    requiresSpecialDigestion: true
+    delay: 15
+    forceFeedDelay: 15
+  - type: BadFood
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 10
+  - type: FlavorProfile
+    flavors:
+    - paper
+    ignoreReagents:
+    - Fiber
+  # Goobstation Edit End
+  - type: AddComponentsOnInteract
+    popupText: book-combat-training-success
+    components:
+    - type: CombatTrained

--- a/Resources/Prototypes/_BRatbite/Roles/Jobs/Csec/redsightoverseer.yml
+++ b/Resources/Prototypes/_BRatbite/Roles/Jobs/Csec/redsightoverseer.yml
@@ -46,6 +46,7 @@
       - type: CommandStaff
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: RSOGear

--- a/Resources/Prototypes/_BRatbite/Roles/Jobs/DeptGuards/DeptGuards.yml
+++ b/Resources/Prototypes/_BRatbite/Roles/Jobs/DeptGuards/DeptGuards.yml
@@ -32,6 +32,7 @@
     components:
       - type: Condemned
         soulOwnedNotDevil: true # Bootlicker for NT
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: MedicalOrderlyGear
@@ -78,6 +79,7 @@
     components:
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: CargoInsuranceGear
@@ -122,6 +124,7 @@
     components:
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: ScicurityguardGear
@@ -170,6 +173,7 @@
     components:
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: CombatTrained # ratbite
   - !type:AddComponentSpecial
     components:
     - type: EngineeringStaff

--- a/Resources/Prototypes/_BRatbite/Traits/traits.yml
+++ b/Resources/Prototypes/_BRatbite/Traits/traits.yml
@@ -161,3 +161,14 @@
   - Oni
   components:
   - type: CombatTrained
+
+- type: trait
+  id: ScaredOfGuns
+  name: trait-scared-of-guns-name
+  description: trait-scared-of-guns-desc
+  category: Mental
+  cost: -3
+  speciesBlacklist:
+  - Oni
+  components:
+    - type: ScaredOfGuns

--- a/Resources/Prototypes/_BRatbite/Traits/traits.yml
+++ b/Resources/Prototypes/_BRatbite/Traits/traits.yml
@@ -150,3 +150,14 @@
   cost: 0
   components:
   - type: Atheist
+
+- type: trait
+  id: CombatTrained
+  name: trait-combat-trained-name
+  description: trait-combat-trained-desc
+  category: Mental
+  cost: 2
+  speciesBlacklist:
+  - Oni
+  components:
+  - type: CombatTrained

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/blueshield_officer.yml
@@ -83,6 +83,7 @@
       - type: CommandStaff
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: CombatTrained # ratbite
 
 - type: startingGear
   id: BlueshieldOfficerGear


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add combat training trait.
By default, entities are not trained in combat, and receive the following debuffs:
- times 2 higher recoil
- 5 flat recoil debuff
- ~~5% chance to miss their shot (As in, you just don't shoot)~~
- ~~1% chance to drop their gun~~


The combat training trait negates these effects and costs 2 points.

The following jobs will spawn with the trait regardless of if they have selected it or not:
- Security roles (Cadet, Officer, Detective, Warden, Hos)
- Captain (Note: HoP does not have it)
- Departmental guards
- Most centcom roles (RSO, BSO, CCO). Note: NTR does NOT have it.
- ERT and Deathsquad
- Nuclear operatives

Added Scared of guns trait. This traits gives you +3 points and a 10% chance to drop guns when shooting and a 20% chance to not shoot at all.

Added a "Robust 101" book, it has a 25% chance of spawning in security lockers or it can be bought in cargo for 1000$. It allows people to obtain the Combat Trained trait when reading

## Why / Balance
More roleplay potential and it's an indirect buff to security. Gives a reason for non combat oriented characters to not just pick up a gun and start fighting.

## Media
<img width="773" height="114" alt="image" src="https://github.com/user-attachments/assets/bdd1bca7-eb62-4e37-be5f-1679513ae6ab" />
<img width="674" height="94" alt="image" src="https://github.com/user-attachments/assets/23971b3a-f1b5-40a4-8484-535120e68103" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Combat trained trait