### PR TITLE
Blood pack changes

### DIFF
--- a/Content.Shared/Medical/Healing/HealingComponent.cs
+++ b/Content.Shared/Medical/Healing/HealingComponent.cs
@@ -15,8 +15,9 @@ public sealed partial class HealingComponent : Component
     /// <remarks>
     /// The amount of damage to heal per use.
     /// </remarks>
-    [DataField(required: true), AutoNetworkedField]
-    public DamageSpecifier Damage = default!;
+    // Ratbite: Make it non required
+    [DataField, AutoNetworkedField]
+    public DamageSpecifier Damage = new();
 
     /// <remarks>
     /// This should generally be negative,

--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -240,7 +240,8 @@ public sealed class HealingSystem : EntitySystem
         if (TryComp<BloodstreamComponent>(target, out var bloodstream))
         {
             // Is ent missing blood that we can restore?
-            if (healing.Comp.ModifyBloodLevel > 0
+            // Ratbite: Change > to <
+            if (healing.Comp.ModifyBloodLevel < 0
                 && _solutionContainerSystem.ResolveSolution(target.Owner, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
                 && bloodSolution.Volume < bloodSolution.MaxVolume)
             {
@@ -544,14 +545,11 @@ public sealed class HealingSystem : EntitySystem
     {
         if (!TryComp<DamageableComponent>(target, out var targetDamage))
             return false;
-
+        // Ratbite: Removed the stupid blood copy pasted check. It's already handled in
+        // HasDamage
         return HasDamage(healing, (target, targetDamage)) ||
             TryComp<BodyComponent>(target, out var bodyComp) && // I'm paranoid, sorry.
-            IsBodyDamaged((target, bodyComp), user, healing.Comp) ||
-            healing.Comp.ModifyBloodLevel > 0 // Special case if healing item can restore lost blood...
-                && TryComp<BloodstreamComponent>(target, out var bloodstream)
-                && _solutionContainerSystem.ResolveSolution(target, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
-                && bloodSolution.Volume < bloodSolution.MaxVolume;
+            IsBodyDamaged((target, bodyComp), user, healing.Comp);
     }
     // Goobstation end
 
@@ -574,14 +572,12 @@ public sealed class HealingSystem : EntitySystem
             return false;
 
         // Shitmed Change Start
+        // Ratbite: Removed the stupid blood copy pasted check. It's already handled in
+        // HasDamage
         var anythingToDo =
             HasDamage(healing, (target.Owner, target.Comp)) ||
             TryComp<BodyComponent>(target, out var bodyComp) && // I'm paranoid, sorry.
-            IsBodyDamaged((target, bodyComp), user, healing.Comp) ||
-            healing.Comp.ModifyBloodLevel < 0 // Special case if healing item can restore lost blood... Goobstation edit
-                && TryComp<BloodstreamComponent>(target, out var bloodstream)
-                && _solutionContainerSystem.ResolveSolution(target.Owner, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution, out var bloodSolution)
-                && bloodSolution.Volume < bloodSolution.MaxVolume; // ...and there is lost blood to restore.
+            IsBodyDamaged((target, bodyComp), user, healing.Comp);
 
         if (!anythingToDo)
         {

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -342,9 +342,6 @@
   - type: Healing
     damageContainers:
       - Biological
-    damage:
-      types:
-        Bloodloss: -2.5 #lowers bloodloss damage, was .5 buffed due to Limb Damage Changes (Goobstation)
     modifyBloodLevel: -30 #used to restore 5% blood per use, now restores about 10% blood per use on standard Buffed due to Limb Damage Changes (Goobstation)
     healingBeginSound:
       path: "/Audio/Items/Medical/brutepack_begin.ogg"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Remove flat 2.5 bloodloss heal from bloodpack.
Fix issue where players would not keep using the bloodpack until bloodlevel was at 100%

## Why / Balance
2.5 bloodloss heal was so small that it was useless, and it caused bloodpacks to attempt to heal until that number got to 0, causing many players to essentially waste them (Bloodloss heals automatically when blood level is above 90%).
This change should make bloodpacks feel more like other topicals, where you don't have to use a health scanner to utilize them efficiently.

## Technical details
Removed some goob copy pasted code that was wrong and stupid
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Blood packs are more intuitive now
