### PR TITLE
Fix modsuits spamming fail sound and dropping items

### DIFF
--- a/Content.Goobstation.Shared/Clothing/Systems/SharedSealableClothingSystem.cs
+++ b/Content.Goobstation.Shared/Clothing/Systems/SharedSealableClothingSystem.cs
@@ -123,7 +123,7 @@ public abstract class SharedSealableClothingSystem : EntitySystem
 
         var slot = control.Comp.RequiredControlSlot.ToString().ToLowerInvariant();
         var wearer = control.Comp.WearerEntity;
-        _inventorySystem.TryUnequip(wearer.Value, wearer.Value, slot, force:true);
+        _inventorySystem.TryUnequip(wearer.Value, wearer.Value, slot, force: true);
         _inventorySystem.TryEquip(wearer.Value, wearer.Value, control, slot, force: true);
         control.Comp.UnequipAfterUnseal = false;
     }
@@ -339,7 +339,8 @@ public abstract class SharedSealableClothingSystem : EntitySystem
         if (comp.IsInProcess)
         {
             _popupSystem.PopupClient(Loc.GetString(comp.UnsealedInProcessToggleFailPopup), uid, args.User);
-            _audioSystem.PlayPvs(comp.FailSound, uid);
+            // Ratbite: use playPredicted to prevent sound spam
+            _audioSystem.PlayPredicted(comp.FailSound, uid, args.User);
             args.Cancel();
             return;
         }
@@ -358,7 +359,8 @@ public abstract class SharedSealableClothingSystem : EntitySystem
         if (!args.Multiple)
         {
             _popupSystem.PopupClient(Loc.GetString(comp.CurrentlySealedToggleFailPopup), uid, args.User);
-            _audioSystem.PlayPvs(comp.FailSound, uid);
+            // Ratbite: use playPredicted to prevent sound spam
+            _audioSystem.PlayPredicted(comp.FailSound, uid, args.User);
             args.Cancel();
             return;
         }
@@ -498,7 +500,7 @@ public abstract class SharedSealableClothingSystem : EntitySystem
                 comp.IsCurrentlySealed ? sealableComponent.SealDownPopup : sealableComponent.SealUpPopup,
                 ("partName", Identity.Name(processingPart, EntityManager))
             );
-            var type = comp.IsCurrentlySealed ?  PopupType.SmallCaution :  PopupType.Small;
+            var type = comp.IsCurrentlySealed ? PopupType.SmallCaution : PopupType.Small;
             _popupSystem.PopupCoordinates(popupText, popupCoords, comp.WearerEntity.Value, type);
 
             break;
@@ -522,7 +524,7 @@ public abstract class SharedSealableClothingSystem : EntitySystem
         foreach (var part in attachedParts)
         {
             if (TryComp<SealableClothingComponent>(part, out var pSeal) && pSeal.IsSealed)
-                    continue;
+                continue;
             allpartsSealed = false;
             break;
         }

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -308,6 +308,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
         var parts = comp.ClothingUids;
         var affectedParts = new List<(EntityUid, string)>();
+        var suitStorageItem = FindSuitStorage(args.Equipee);
 
         // if your toggleable clothing is a backslot and gets forcefully removed i.e. gibbing, Robust likes to forcefully eject the container(s)
         // you can try this by making a regular outerclothing item a back item with VV and equipping the toggle, then smiting yourself
@@ -340,8 +341,10 @@ public sealed class ToggleableClothingSystem : EntitySystem
                 var ev = new ToggledBackClothingFullUnequipAndInsertedEvent(toggleable.Owner, args.Equipee, affectedParts);
                 RaiseLocalEvent(toggleable.Owner, ref ev);
             }
+            ForceSuitStorage(args.Equipee, suitStorageItem);
             return;
         }
+
 
         foreach (var (partUid, slot) in parts)
         {
@@ -350,6 +353,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
             _inventorySystem.TryUnequip(args.Equipee, slot, force: true, triggerHandContact: true);
         }
+        ForceSuitStorage(args.Equipee, suitStorageItem);
     }
 
     private void OnRemoveToggleable(Entity<ToggleableClothingComponent> toggleable, ref ComponentRemove args)
@@ -545,13 +549,12 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (!container!.Contains(attachedUid))
         {
             UnequipClothing(user, toggleable, attachedUid, slot!);
-            ForceSuitStorage(user, suitStorageItem);
         }
         else
         {
             EquipClothing(user, toggleable, attachedUid, slot!);
-            ForceSuitStorage(user, suitStorageItem);
         }
+        ForceSuitStorage(user, suitStorageItem);
     }
 
     /// <summary>
@@ -565,14 +568,13 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
         if (!CanToggleClothing(user, toggleable, true))
             return;
-
+        var suitStorageItem = FindSuitStorage(user);
         if (GetAttachedToggleStatus(user, toggleable, false, comp) == ToggleableClothingAttachedStatus.NoneToggled)
         {
             foreach (var clothing in attachedClothings)
             {
-                var suitStorageItem = FindSuitStorage(user);
                 EquipClothing(user, toggleable, clothing.Key, clothing.Value);
-                ForceSuitStorage(user, suitStorageItem);
+
             }
         }
         else
@@ -581,12 +583,11 @@ public sealed class ToggleableClothingSystem : EntitySystem
             {
                 if (!container!.Contains(clothing.Key))
                 {
-                    var suitStorageItem = FindSuitStorage(user);
                     UnequipClothing(user, toggleable, clothing.Key, clothing.Value);
-                    ForceSuitStorage(user, suitStorageItem);
                 }
             }
         }
+        ForceSuitStorage(user, suitStorageItem);
     }
 
     private bool CanToggleClothing(EntityUid user, Entity<ToggleableClothingComponent> toggleable, bool multiple)

--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -194,7 +194,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
 
         if (comp.StripDelay == null)
             return;
-        var (time, stealth, _) = _strippable.GetStripTimeModifiers(user, wearer, acomp.AttachedUid, comp.StripDelay.Value*3/4); // 3/4's of toggleable
+        var (time, stealth, _) = _strippable.GetStripTimeModifiers(user, wearer, acomp.AttachedUid, comp.StripDelay.Value * 3 / 4); // 3/4's of toggleable
 
         var args = new DoAfterArgs(EntityManager, user, time, new AttachClothingDoAfterEvent(), attached, wearer, attached)
         {
@@ -246,7 +246,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
     }
 
     public bool IsToggled(Entity<ToggleableClothingComponent> ent, EntityUid clothing) // Goobstation
-///
+    ///
     {
         return !ent.Comp.Container.Contains(clothing);
     }
@@ -530,13 +530,14 @@ public sealed class ToggleableClothingSystem : EntitySystem
     /// </summary>
     private void ToggleClothing(EntityUid user, Entity<ToggleableClothingComponent> toggleable, EntityUid attachedUid)
     {
+        // Ratbite: put check at the start to fix unequip
+        if (!CanToggleClothing(user, toggleable, false))
+            return;
+
         var suitStorageItem = FindSuitStorage(user);
         var comp = toggleable.Comp;
         var attachedClothings = comp.ClothingUids;
         var container = comp.Container;
-
-        if (!CanToggleClothing(user, toggleable, false))
-            return;
 
         if (!attachedClothings.TryGetValue(attachedUid, out var slot) || string.IsNullOrEmpty(slot))
             return;
@@ -629,7 +630,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
         var storedClothing = attachedComp.ClothingContainer.ContainedEntity;
 
         if (storedClothing != null)
-            _inventorySystem.TryEquip(parent, storedClothing.Value, slot, force: true, triggerHandContact: true, silent:true);
+            _inventorySystem.TryEquip(parent, storedClothing.Value, slot, force: true, triggerHandContact: true, silent: true);
     }
     public bool EquipClothing(EntityUid user, Entity<ToggleableClothingComponent> toggleable, EntityUid clothing, string slot, bool silent = false) // Goobstation
     {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fix bug where, if you tried to unequip any piece of item from the modsuit using the wheel selector while the modsuit was sealed, the item on your back would fall off for no apparent reason.
Also fixed the fail sound playing multiple times

## Why / Balance
Bug fix
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="170" height="107" alt="image" src="https://github.com/user-attachments/assets/8e0f97d7-5b3d-4860-b66f-b5c097a187d0" />
Jetpack still equipped

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fix items on the back dropping on modsuit unequip when sealed
