### PR TITLE
Allow synthcells to fill hollowed out bodies

### DIFF
--- a/Content.Goobstation.Common/Changeling/AbsorbedComponent.cs
+++ b/Content.Goobstation.Common/Changeling/AbsorbedComponent.cs
@@ -9,8 +9,14 @@ using Robust.Shared.GameStates;
 
 namespace Content.Goobstation.Common.Changeling;
 
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class AbsorbedComponent : Component
 {
+    // Ratbite: allow dehusking
+    [DataField]
+    public bool CanDehusk = true;
 
+    // Ratbite: allow dehusking
+    [DataField, AutoNetworkedField]
+    public bool Dehusked = false;
 }

--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.Abilities.cs
@@ -175,7 +175,7 @@ public sealed partial class ChangelingSystem
         };
         _doAfter.TryStartDoAfter(dargs);
     }
-    public ProtoId<DamageGroupPrototype> AbsorbedDamageGroup = "Genetic";
+    public ProtoId<DamageGroupPrototype> AbsorbedDamageGroup = "Airloss";
     private void OnAbsorbDoAfter(EntityUid uid, ChangelingIdentityComponent comp, ref AbsorbDNADoAfterEvent args)
     {
         if (args.Args.Target == null)
@@ -193,7 +193,9 @@ public sealed partial class ChangelingSystem
         _blood.ChangeBloodReagent(target, "FerrochromicAcid");
         _blood.SpillAllSolutions(target);
 
-        EnsureComp<AbsorbedComponent>(target);
+	// Ratbite: don't let already unrevived entities be dehusked
+        var absorbedComponent = EnsureComp<AbsorbedComponent>(target);
+	absorbedComponent.CanDehusk = !HasComp<UnrevivableComponent>(target);
         EnsureComp<UnrevivableComponent>(target);
 
         var popup = string.Empty;
@@ -439,7 +441,7 @@ public sealed partial class ChangelingSystem
             _popup.PopupEntity(Loc.GetString("changeling-stasis-exit-fail"), uid, uid);
             return;
         }
-        if (HasComp<AbsorbedComponent>(uid))
+        if (TryComp<AbsorbedComponent>(uid, out var absorbed) && !absorbed.Dehusked)
         {
             _popup.PopupEntity(Loc.GetString("changeling-stasis-exit-fail-dead"), uid, uid);
             return;

--- a/Content.Goobstation.Shared/Changeling/Systems/AbsorbedSystem.cs
+++ b/Content.Goobstation.Shared/Changeling/Systems/AbsorbedSystem.cs
@@ -27,11 +27,13 @@ public sealed partial class AbsorbedSystem : EntitySystem
 
     private void OnExamine(Entity<AbsorbedComponent> ent, ref ExaminedEvent args)
     {
+	if (ent.Comp.Dehusked) return;
         args.PushMarkup(Loc.GetString("changeling-absorb-onexamine"));
     }
 
     private void OnMobStateChange(Entity<AbsorbedComponent> ent, ref MobStateChangedEvent args)
     {
+	if (ent.Comp.Dehusked) return;
         // in case one somehow manages to dehusk someone
         if (args.NewMobState != MobState.Dead)
             RemComp<AbsorbedComponent>(ent);

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -339,7 +339,7 @@ namespace Content.Server.Kitchen.EntitySystems
                 _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-deny-changeling", ("victim", Identity.Entity(victimUid, EntityManager)), ("this", uid)), victimUid, userUid);
                 return false;
             }
-            if (HasComp<AbsorbedComponent>(victimUid))
+            if (TryComp<AbsorbedComponent>(victimUid, out var absorbed) && !absorbed.Dehusked)
             {
                 _popupSystem.PopupEntity(Loc.GetString("comp-kitchen-spike-deny-absorbed", ("victim", Identity.Entity(victimUid, EntityManager)), ("this", uid)), victimUid, userUid);
                 return false;

--- a/Content.Server/_BRatbite/EntityEffects/Effects/DehuskEffect.cs
+++ b/Content.Server/_BRatbite/EntityEffects/Effects/DehuskEffect.cs
@@ -1,0 +1,22 @@
+using Content.Goobstation.Common.Changeling;
+using Content.Shared.EntityEffects;
+using Content.Shared.Popups;
+using Content.Shared.Traits.Assorted;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._BRatbite.EntityEffects.Effects;
+
+public sealed partial class DehuskEffect : EntityEffect
+{
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if(!args.EntityManager.TryGetComponent<AbsorbedComponent>(args.TargetEntity, out var absorbedComponent)) return;
+	if (!absorbedComponent.CanDehusk || absorbedComponent.Dehusked) return;
+
+        absorbedComponent.Dehusked = true;
+        args.EntityManager.RemoveComponent<UnrevivableComponent>(args.TargetEntity);
+        var popup = args.EntityManager.EntitySysManager.GetEntitySystem<SharedPopupSystem>();
+        popup.PopupEntity(Loc.GetString("dehusk-effect-popup"), args.TargetEntity);
+    }
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys) => Loc.GetString("dehusk-effect-guidebook-text");
+}

--- a/Resources/Locale/en-US/_BRatbite/effects/dehusk-effect.ftl
+++ b/Resources/Locale/en-US/_BRatbite/effects/dehusk-effect.ftl
@@ -1,0 +1,2 @@
+dehusk-effect-popup = The synthetic cells quickily get into the hollowed body and start filling it from the inside. You may be able to revive this body now.
+dehusk-effect-guidebook-text = This medicine is able to quickily fill hollowed out bodies

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -957,6 +957,12 @@
           components:
           - type: PressureProtection # can't get through this to reach the bodyparts!
           invert: true
+      - !type:DehuskEffect
+        conditions:
+        - !type:HasComponentOnEquipmentCondition
+          components:
+          - type: PressureProtection # can't get through this to reach the bodyparts!
+          invert: true
   metabolisms:
     Medicine:
       effects:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
- Change damage type when linged from genetic to airloss
- Make synthcells fill a husked body, allowing it to be revived once again (Unless they were already unrevivable before, for example they had the unrevivable trait). Note: This does not allow lings to absorb the body again.
## Why / Balance

Make hollowed bodies allow to be revived, reducing RR's from ling
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="798" height="256" alt="image" src="https://github.com/user-attachments/assets/42141ce2-8d37-45fd-bce0-c7b704906fdf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
