### PR TITLE
Uncap hos sword damage on prisoners

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/BurnBodyBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/BurnBodyBehavior.cs
@@ -23,6 +23,13 @@ public sealed partial class BurnBodyBehavior : IThresholdBehavior
 
     public void Execute(EntityUid bodyId, DestructibleSystem system, EntityUid? cause = null)
     {
+        // Ratbite: make it work with shitmed
+        if (system.EntityManager.TryGetComponent(bodyId, out BodyPartComponent? bodyPart) && bodyPart.Body != null)
+        {
+            Execute(bodyPart.Body.Value, system, cause);
+            return;
+        }
+
         var transformSystem = system.EntityManager.System<TransformSystem>();
         var inventorySystem = system.EntityManager.System<InventorySystem>();
         var sharedPopupSystem = system.EntityManager.System<SharedPopupSystem>();

--- a/Content.Shared/Damage/Systems/DamageableSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageableSystem.cs
@@ -179,8 +179,8 @@ namespace Content.Shared.Damage
             }, true);
             Subs.CVar(_config, CCVars.PlaytestReagentHealModifier, value =>
             {
-                 UniversalReagentHealModifier = value;
-                 _chemistryGuideData.ReloadAllReagentPrototypes();
+                UniversalReagentHealModifier = value;
+                _chemistryGuideData.ReloadAllReagentPrototypes();
             }, true);
             Subs.CVar(_config, CCVars.PlaytestExplosionDamageModifier, value => UniversalExplosionDamageModifier = value, true);
             Subs.CVar(_config, CCVars.PlaytestThrownDamageModifier, value => UniversalThrownDamageModifier = value, true);
@@ -512,6 +512,8 @@ namespace Content.Shared.Damage
             if (!Resolve(uid, ref damageable) || damage == null)
                 return null;
 
+            bool skipCap = false;
+
             // Apply resistances
             if (!ignoreResistances)
             {
@@ -528,21 +530,24 @@ namespace Content.Shared.Damage
                     if (bodyPart.Body != null)
                     {
                         // First raise the event on the parent to apply any parent modifiers
-                        var parentEv = new DamageModifyEvent(bodyPart.Body.Value, damage, origin, target);
+                        var parentEv = new DamageModifyEvent(bodyPart.Body.Value, damage, origin, target, skipCap);
                         RaiseLocalEvent(bodyPart.Body.Value, parentEv);
                         damage = parentEv.Damage;
+                        skipCap = parentEv.SkipCap;
                     }
 
                     // Then raise on the part itself for any part-specific modifiers
-                    var ev = new DamageModifyEvent(uid, damage, origin, target);
+                    var ev = new DamageModifyEvent(uid, damage, origin, target, skipCap);
                     RaiseLocalEvent(uid, ev);
+                    skipCap = ev.SkipCap;
                     damage = ev.Damage;
                 }
                 else
                 {
                     // Not a body part, just apply modifiers normally
-                    var ev = new DamageModifyEvent(uid, damage, origin);
+                    var ev = new DamageModifyEvent(uid, damage, origin, skipCap: skipCap);
                     RaiseLocalEvent(uid, ev);
+                    skipCap = ev.SkipCap;
                     damage = ev.Damage;
                 }
 
@@ -569,7 +574,7 @@ namespace Content.Shared.Damage
 
             // Apply damage
             var currentTotalDamage = damageable.TotalDamage.Float();
-            FixedPoint2? remainingCap = damageCap.HasValue ? damageCap.Value - currentTotalDamage : null;
+            FixedPoint2? remainingCap = (damageCap.HasValue && !skipCap) ? damageCap.Value - currentTotalDamage : null;
 
             foreach (var (type, value) in damage.DamageDict)
             {
@@ -1070,14 +1075,16 @@ namespace Content.Shared.Damage
         public DamageSpecifier Damage;
         public EntityUid? Origin;
         public readonly TargetBodyPart? TargetPart; // Shitmed Change
+        public bool SkipCap;
 
-        public DamageModifyEvent(EntityUid target, DamageSpecifier damage, EntityUid? origin = null, TargetBodyPart? targetPart = null) // Shitmed + Goobstation Change
+        public DamageModifyEvent(EntityUid target, DamageSpecifier damage, EntityUid? origin = null, TargetBodyPart? targetPart = null, bool skipCap = false) // Shitmed + Goobstation Change
         {
             Target = target; // Goobstation
             OriginalDamage = damage;
             Damage = damage;
             Origin = origin;
             TargetPart = targetPart; // Shitmed Change
+            SkipCap = skipCap;
         }
     }
 

--- a/Content.Shared/_BRatbite/Weapons/Melee/SaberDamageSystem.cs
+++ b/Content.Shared/_BRatbite/Weapons/Melee/SaberDamageSystem.cs
@@ -39,6 +39,7 @@ public sealed class SaberDamageSystem : EntitySystem
             {
                 var remainingSentence = (ent.Comp.PermaBrigSentenceExpireTime - _gameTiming.CurTime).TotalMinutes;
                 args.Damage += (hosSaber.DamageMultiplierPerMinute * (float) Math.Max(remainingSentence, 0) * args.Damage);
+                args.SkipCap = true;
             }
         }
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Uncap HOS damage on perma prisoners

## Why / Balance
It was intended to be uncapped in the original PR

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/6316ab48-a7d5-4fc1-b892-a5e723ce59a3



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Uncap hos' sword damage on prisoners
