### PR TITLE
Add weak puller component and give it to critters

### DIFF
--- a/Content.Shared/_BRatbite/Movement/Pulling/WeakPullerComponent.cs
+++ b/Content.Shared/_BRatbite/Movement/Pulling/WeakPullerComponent.cs
@@ -1,0 +1,11 @@
+using Content.Shared.Item;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._BRatbite.Movement.Pulling;
+
+[RegisterComponent]
+public sealed partial class WeakPullerComponent : Component
+{
+    [DataField]
+    public ProtoId<ItemSizePrototype> MaxPullableSize = "Small";
+}

--- a/Content.Shared/_BRatbite/Movement/Pulling/WeakPullerSystem.cs
+++ b/Content.Shared/_BRatbite/Movement/Pulling/WeakPullerSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Item;
+using Content.Shared.Movement.Pulling.Events;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._BRatbite.Movement.Pulling;
+
+public sealed partial class WeakPullerSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<WeakPullerComponent, PullAttemptEvent>(OnPullAttempt);
+    }
+
+    private void OnPullAttempt(Entity<WeakPullerComponent> ent, ref PullAttemptEvent args)
+    {
+        if (args.Cancelled) return;
+        // Weak pulles cannot pull non items
+        if (!TryComp<ItemComponent>(args.PulledUid, out var itemComp) || !_proto.TryIndex(itemComp.Size, out var itemSize) || !_proto.TryIndex(ent.Comp.MaxPullableSize, out var maxPullableSize) || itemSize > maxPullableSize)
+        {
+            args.Cancelled = true;
+            _popup.PopupClient(Loc.GetString("weak-puller-too-big"), ent.Owner, ent.Owner);
+            return;
+        }
+    }
+}

--- a/Resources/Locale/en-US/_BRatbite/weak-puller/weak-puller.ftl
+++ b/Resources/Locale/en-US/_BRatbite/weak-puller/weak-puller.ftl
@@ -1,0 +1,1 @@
+weak-puller-too-big = You try pulling at the enormous item, but it doesn't budge. You aren't strong enough.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -287,6 +287,11 @@
   id: MobBat
   description: Some cultures find them terrifying, others crunchy on the teeth.
   components:
+  # Ratbite: allow critters to pull stuff
+  - type: Puller
+    needsHands: false
+  - type: WeakPuller
+  # End ratbite
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
     baseSprintSpeed : 6
@@ -640,6 +645,11 @@
   id: MobCockroach
   description: This station is just crawling with bugs.
   components:
+  # Ratbite: allow critters to pull stuff
+  - type: Puller
+    needsHands: false
+  - type: WeakPuller
+  # End ratbite
   - type: Sprite
     drawdepth: SmallMobs
     sprite: Mobs/Animals/cockroach.rsi
@@ -2046,6 +2056,11 @@
   id: MobMouse
   description: Squeak!
   components:
+  # Ratbite: allow critters to pull stuff
+  - type: Puller
+    needsHands: false
+  - type: WeakPuller
+  # End ratbite
   - type: VentCrawler # goobstation - Ventcrawl
     enterDelay: 0.5
   - type: Body
@@ -3869,6 +3884,11 @@
   description: A cute, fluffy, robust hamster.
   components:
   - type: VentCrawler # goobstation - Ventcrawl
+  # Ratbite: allow critters to pull stuff
+  - type: Puller
+    needsHands: false
+  - type: WeakPuller
+  # End ratbite
   - type: GhostRole
     makeSentient: true
     allowSpeech: true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add Weak Puller Component. These pullers can only pull items that are smaller or equal than a specified size (Small by default).
Add this component to some critters (Mouse, bat, hamster, cockroaches, mothroaches)

## Why / Balance
Allow pulling

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="1030" height="466" alt="image" src="https://github.com/user-attachments/assets/cf9c66b8-d057-46fa-91b6-0f1dd1b02e16" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mice and other critters can now pull small items
