### PR TITLE
Fix Thunderdome

### DIFF
--- a/Content.Goobstation.Server/MisandryBox/Thunderdome/ThunderdomeLoadoutEui.cs
+++ b/Content.Goobstation.Server/MisandryBox/Thunderdome/ThunderdomeLoadoutEui.cs
@@ -50,5 +50,6 @@ public sealed class ThunderdomeLoadoutEui : BaseEui
     public override void Closed()
     {
         base.Closed();
+        _thunderdomeSystem.RemoveActiveEui(_session, this);
     }
 }

--- a/Content.Goobstation.Server/MisandryBox/Thunderdome/ThunderdomeRuleSystem.cs
+++ b/Content.Goobstation.Server/MisandryBox/Thunderdome/ThunderdomeRuleSystem.cs
@@ -105,7 +105,7 @@ public sealed class ThunderdomeRuleSystem : EntitySystem
 
     private void OnRoundEnding(RoundRestartCleanupEvent ev)
     {
-        foreach (var eui in _activeEuis.Values)
+        foreach (var eui in _activeEuis.Values.ToList())
             eui.Close();
         _activeEuis.Clear();
 
@@ -165,6 +165,14 @@ public sealed class ThunderdomeRuleSystem : EntitySystem
         var eui = new ThunderdomeLoadoutEui(this, _ruleEntity.Value, session);
         _euiManager.OpenEui(eui, session);
         _activeEuis[session] = eui;
+    }
+
+    internal void RemoveActiveEui(ICommonSession session, ThunderdomeLoadoutEui eui)
+    {
+        if (_activeEuis.TryGetValue(session, out var activeEui) && ReferenceEquals(activeEui, eui))
+        {
+            _activeEuis.Remove(session);
+        }
     }
 
     private void OnLeaveRequest(ThunderdomeLeaveRequestEvent ev, EntitySessionEventArgs args)

--- a/Content.Server/EUI/EuiManager.cs
+++ b/Content.Server/EUI/EuiManager.cs
@@ -90,7 +90,11 @@ namespace Content.Server.EUI
         public void CloseEui(BaseEui eui)
         {
             eui.Shutdown();
-            _playerData[eui.Player].OpenUIs.Remove(eui.Id);
+
+            if (_playerData.TryGetValue(eui.Player, out var plyDat))
+            {
+                plyDat.OpenUIs.Remove(eui.Id);
+            }
 
             var msg = new MsgEuiCtl();
             msg.Id = eui.Id;


### PR DESCRIPTION
Description:
fixed thunderdome

What was happening:
The Thunderdome system keeps a reference to the open UI, even after player disconnect. When the round restarts, it tries to reference that UI to close it... But the EUI manager has already deleted the disconnected player's session data.
The path to close the UI looks up a player entry that no longer exists and thows a KeyNotFoundException.
Then, the EUI Manager just trusts that the entry will be parsed without error, and of course there's an error here. So it gets caught in a loop and the server fucking implodes.

TLDR of what was changed to fix it:
Added validation to EUI manager to ensure it will only parse if the reference actually points to an existing entry.
Added cleanup stage to the Thunderdome loadout UI