### PR TITLE
Make antagonists not be able to target people who don't have that antag enabled

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -122,6 +122,8 @@ using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
 using Content.Shared.Mind;
 using Content.Shared.Players;
+using Content.Shared.Popups;
+using Content.Shared.Preferences;
 using Content.Shared.Roles;
 using Content.Shared.Whitelist;
 using Robust.Server.Audio;
@@ -153,6 +155,8 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     [Dependency] private readonly LastRolledAntagManager _lastRolled = default!; // Goobstation
     [Dependency] private readonly PlayTimeTrackingManager _playTime = default!; // Goobstation
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     // arbitrary random number to give late joining some mild interest.
     public const float LateJoinRandomChance = 0.5f;
@@ -184,6 +188,19 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (!Exists(rule) || !TryComp<AntagSelectionComponent>(rule, out var select))
             return;
+
+        // Ratbite start
+        var selectableRoles = def.PrefRoles.Select(a => (a, _proto.Index(a))).Where(a => a.Item2.SetPreference).ToList();
+        if (selectableRoles.Count() > 0 && _pref.TryGetCachedPreferences(args.Player.UserId, out var pref))
+        {
+            var profile = pref.SelectedCharacter;
+            if (profile is HumanoidCharacterProfile humanoid && !selectableRoles.Any(a => humanoid.AntagPreferences.Contains(a.Item1)))
+            {
+                _popup.PopupCursor(Loc.GetString("antag-ghost-role-not-allowed"), args.Player);
+                return;
+            }
+        }
+        // Ratbite end
 
         MakeAntag((rule, select), args.Player, def, ignoreSpawner: true);
         args.TookRole = true;

--- a/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ParadoxCloneRuleSystem.cs
@@ -11,10 +11,12 @@ using Content.Server.Cloning;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Medical.SuitSensors;
 using Content.Server.Objectives.Components;
+using Content.Server.Preferences.Managers;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Gibbing.Components;
 using Content.Shared.Medical.SuitSensor;
 using Content.Shared.Mind;
+using Content.Shared.Preferences;
 using Content.Shared.Whitelist;
 using Robust.Shared.Random;
 
@@ -28,6 +30,7 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
     [Dependency] private readonly CloningSystem _cloning = default!;
     [Dependency] private readonly SuitSensorSystem _sensor = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // Goobstation
+    [Dependency] private readonly IServerPreferencesManager _preferences = default!;
 
     public override void Initialize()
     {
@@ -72,6 +75,15 @@ public sealed class ParadoxCloneRuleSystem : GameRuleSystem<ParadoxCloneRuleComp
             // get possible targets
             var allAliveHumanoids = _mind.GetAliveHumans();
             allAliveHumanoids.RemoveWhere(human => _whitelist.IsBlacklistPass(ent.Comp.TargetBlacklist, human)); // Goobstation
+                                                                                                                 // Ratbite: Remove targets who don't have paradox clone enabled
+            allAliveHumanoids.RemoveWhere((mind) =>
+            {
+                if (mind.Comp.UserId is null) return false;
+                if (!_preferences.TryGetCachedPreferences(mind.Comp.UserId.Value, out var pref)) return false;
+                var profile = pref.SelectedCharacter;
+                if (profile is not HumanoidCharacterProfile humanoid) return false;
+                return !humanoid.AntagPreferences.Contains("ParadoxClone");
+            });
 
             // we already checked when starting the gamerule, but someone might have died since then.
             if (allAliveHumanoids.Count == 0)

--- a/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
+++ b/Content.Server/Objectives/Components/PickRandomPersonComponent.cs
@@ -10,6 +10,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Objectives.Systems;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Objectives.Components;
 
@@ -24,4 +26,8 @@ public sealed partial class PickRandomPersonComponent : Component
 
     [DataField]
     public bool ExcludeChangeling; // Goobstation: Determine if you can get changelings as an objective
+
+    [DataField]
+    // Ratbite: Which antag does the person need to have enabled for it to be picked
+    public ProtoId<AntagPrototype>? NeedsAntagSelected;
 }

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -15,6 +15,8 @@ using Content.Server.Revolutionary.Components;
 using Robust.Shared.Random;
 using System.Linq;
 using Content.Shared.NukeOps;
+using Content.Shared.Preferences;
+using Content.Server.Preferences.Managers;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -28,6 +30,7 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
+    [Dependency] private readonly IServerPreferencesManager _preferences = default!;
 
     public override void Initialize()
     {
@@ -86,6 +89,18 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         var allHumans = _mind.GetAliveHumans(args.MindId,
             ent.Comp.NeedsOrganic, ent.Comp.ExcludeChangeling); // Goob edit - exclude IPCs and/or changelings
 
+        // Ratbite start
+        if (ent.Comp.NeedsAntagSelected is { } needsAntagSelected)
+            allHumans.RemoveWhere((mind) =>
+                    {
+                        if (mind.Comp.UserId is null) return false;
+                        if (!_preferences.TryGetCachedPreferences(mind.Comp.UserId.Value, out var pref)) return false;
+                        var profile = pref.SelectedCharacter;
+                        if (profile is not HumanoidCharacterProfile humanoid) return false;
+                        return !humanoid.AntagPreferences.Contains(needsAntagSelected);
+                    });
+        // Ratbite end
+
         // Can't have multiple objectives to kill the same person
         foreach (var objective in args.Mind.Objectives)
         {
@@ -131,7 +146,7 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         {
             if (TryComp<MindComponent>(person, out var mind) && mind.OwnedEntity is { } owned && HasComp<CommandStaffComponent>(owned) && !HasComp<NukeOperativeComponent>(owned))
                 allHeads.Add(person); // Goob edit - exclude nuke ops from being selected as heads (bruh why would you even want that)
-        } 
+        }
 
         // Goobstation - Cancel if there is no command staff
         if (allHeads.Count == 0)

--- a/Resources/Locale/en-US/_BRatbite/antagonists/antagonist.ftl
+++ b/Resources/Locale/en-US/_BRatbite/antagonists/antagonist.ftl
@@ -1,0 +1,1 @@
+antag-ghost-role-not-allowed = You don't have this antagonist selected in your antagonist preferences

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -508,6 +508,8 @@
         sound: /Audio/Misc/paradox_clone_greeting.ogg
       mindRoles:
       - MindRoleParadoxClone
+      # Ratbite
+      prefRoles: [ ParadoxClone ]
 
 #- type: entity   Goobstaion start - disabled until rework
 #  parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -485,6 +485,9 @@
       components:
       - BorgBrain # No copying the AI or borgs.
       - AntagImmune # No copying people who are immune to antags. (Gemini Hologram, Ghost bar, etcetera.)
+      - AbductorScientist
+      - Abductor
+      - Slasher
 
   - type: AntagObjectives
     objectives:

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -183,6 +183,7 @@
   - type: TargetObjective
     title: objective-condition-maroon-person-title
   - type: PickRandomPerson
+    needsAntagSelected: Traitor # Ratbite
   - type: KillPersonCondition
     requireMaroon: true
 

--- a/Resources/Prototypes/Roles/Antags/paradoxClone.yml
+++ b/Resources/Prototypes/Roles/Antags/paradoxClone.yml
@@ -3,7 +3,7 @@
   name: roles-antag-paradox-clone-name
   antagonist: true
   objective: roles-antag-paradox-clone-objective
-  setPreference: false
+  setPreference: true # Ratbite
 
 # they need to be able to espace when spawning inside a locked room
 # TODO: remove this once we got a better spawning loacation selection

--- a/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
@@ -103,6 +103,7 @@
   - type: PickRandomPerson
     needsOrganic: true # Don't pick IPCs.
     excludeChangeling: true # if they swap identities its a guarantee fail
+    needsAntagSelected: Changeling # Ratbite
 
 - type: entity
   parent: [BaseChangelingSyndicateObjective, BaseStealObjective]

--- a/Resources/Prototypes/_Goobstation/Objectives/corporageagent.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/corporageagent.yml
@@ -100,6 +100,7 @@
   - type: TargetObjective
     title: objective-condition-maroon-person-title
   - type: PickRandomPerson
+    needsAntagSelected: CorporateAgent # Ratbite
   - type: KillPersonCondition
     requireMaroon: true
 
@@ -353,6 +354,7 @@
   - type: TargetObjective
     title: objective-condition-pkill-person
   - type: PickRandomPerson
+    needsAntagSelected: CorporateAgent # Ratbite
   - type: KillPersonCondition
     requireDead: true
 

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -48,6 +48,7 @@
   - type: TargetObjective
     title: objective-condition-pkill-person
   - type: PickRandomPerson
+    needsAntagSelected: Traitor # Ratbite
   - type: KillPersonCondition
     requireDead: true
 

--- a/Resources/Prototypes/_StarLight/Objectives/traitor.yml
+++ b/Resources/Prototypes/_StarLight/Objectives/traitor.yml
@@ -29,6 +29,7 @@
   - type: TargetObjective
     title: objective-condition-teach-lesson-title
   - type: PickRandomPerson
+    needsAntagSelected: Traitor # Ratbite
 
 
 - type: entity


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Added Paradox Clone to the antag preference list, if you do not have it enabled, you will not be able to pick it as ghost role.
Make antagonists not be able to target people who don't have that antag enabled, for example if you have "ParadoxClone" disabled, you will never get a paradox clone of yourself.
If you have "Traitor" disabled, you will not have a traitor have you as a kill target (Note: this does not apply to the "Kill head" objective, this is intentional because heads should be targets regardless of if they have the antagonist enabled or not) 
## Why / Balance
Some people don't want to deal with antagonists, and that's why they have them disabled. This allows them to not be an active target (Unless they are a head role)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Antagonists are not able to target people who don't have that antag enabled
