### PR TITLE
Unbolt boltable machine when they get unanchored

### DIFF
--- a/Content.Shared/_BRatbite/Machines/SharedMachineBoltableSystem.cs
+++ b/Content.Shared/_BRatbite/Machines/SharedMachineBoltableSystem.cs
@@ -1,12 +1,6 @@
 using Robust.Shared.Serialization;
 using Content.Shared.Popups;
 using Content.Shared.Construction.Components;
-using Content.Shared.Database;
-using Content.Shared._BRatbite.Machines;
-using Content.Shared.Wires;
-using Robust.Shared.GameObjects;
-using Robust.Shared.Audio.Systems;
-using Content.Shared._BRatbite.Machines;
 
 namespace Content.Shared._BRatbite.Machines;
 
@@ -21,6 +15,7 @@ public abstract class SharedMachineBoltableSystem : EntitySystem
 
         SubscribeLocalEvent<BoltableMachineComponent, AnchorAttemptEvent>(OnAnchorAttempt);
         SubscribeLocalEvent<BoltableMachineComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+        SubscribeLocalEvent<BoltableMachineComponent, AnchorStateChangedEvent>(OnAnchorStateChange);
     }
 
     private void OnAnchorAttempt(Entity<BoltableMachineComponent> ent, ref AnchorAttemptEvent args)
@@ -48,8 +43,12 @@ public abstract class SharedMachineBoltableSystem : EntitySystem
         return false;
     }
 
-
-
+    private void OnAnchorStateChange(Entity<BoltableMachineComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        // Unbolt if the anchor state changes
+        if (!args.Anchored)
+            ent.Comp.Bolted = false;
+    }
 }
 
 [NetSerializable, Serializable]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Unbolt machines when they get unanchored, for example the tile underneath them is removed
## Why / Balance
Bug fix
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Unbolt machines when they get unanchored