### PR TITLE
Cap rat servants to 20

### DIFF
--- a/Content.Server/RatKing/RatKingSystem.cs
+++ b/Content.Server/RatKing/RatKingSystem.cs
@@ -72,6 +72,12 @@ namespace Content.Server.RatKing
                 _popup.PopupEntity(Loc.GetString("rat-king-too-hungry"), uid, uid);
                 return;
             }
+            // Ratbite: Add a cap to servants
+            if (component.Servants.Count + 1 > component.MaxServantsToSpawn)
+            {
+                _popup.PopupEntity(Loc.GetString("rat-king-too-many-servants"), uid, uid);
+                return;
+            }
             args.Handled = true;
             _hunger.ModifyHunger(uid, -component.HungerPerArmyUse, hunger);
             var servant = Spawn(component.ArmyMobSpawnId, Transform(uid).Coordinates);

--- a/Content.Shared/RatKing/RatKingComponent.cs
+++ b/Content.Shared/RatKing/RatKingComponent.cs
@@ -109,6 +109,10 @@ public sealed partial class RatKingComponent : Component
         { RatKingOrderType.CheeseEm, "RatKingCommandCheeseEm" },
         { RatKingOrderType.Loose, "RatKingCommandLoose" }
     };
+
+    // Ratbite
+    [DataField]
+    public int MaxServantsToSpawn = 20;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/RatKing/RatKingComponent.cs
+++ b/Content.Shared/RatKing/RatKingComponent.cs
@@ -112,7 +112,7 @@ public sealed partial class RatKingComponent : Component
 
     // Ratbite
     [DataField]
-    public int MaxServantsToSpawn = 20;
+    public int MaxServantsToSpawn = 35;
 }
 
 [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/_BRatbite/ratking/ratking.ftl
+++ b/Resources/Locale/en-US/_BRatbite/ratking/ratking.ftl
@@ -1,0 +1,1 @@
+rat-king-too-many-servants = You decide that it's best to now raise any more servants, as there are too many to count


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Cap rat king servants to 20

## Why / Balance
Rat king spawns too many rats and lags the server, then security decides to not kill it because they're incompentent
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="614" height="195" alt="image" src="https://github.com/user-attachments/assets/62027890-36d6-4371-9659-5e3b50dfdb56" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cap rat servants to 20
