### PR TITLE
plasma cutter damage

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
@@ -11,7 +11,7 @@
   name: plasma cutter
   parent: BaseWeaponBatterySmall
   id: WeaponPlasmaCutter
-  description: A self-defense weapon that uses condensed plasma to cut through objects and people.
+  description: A self-defense weapon that uses condensed plasma to cut through objects and people. Ineffective against armor.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/cutter.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Basic/plasma_cutter.yml
@@ -11,7 +11,7 @@
   name: plasma cutter
   parent: BaseWeaponBatterySmall
   id: WeaponPlasmaCutter
-  description: A self-defense weapon that exhausts organic targets, weakening them until they collapse.
+  description: A self-defense weapon that uses condensed plasma to cut through objects and people.
   components:
   - type: Sprite
     sprite: _Goobstation/Objects/Weapons/Guns/Battery/cutter.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -85,12 +85,15 @@
       types:
         Heat: 5 # Ratbite - Made plasmacutter deal damage instead of stam damage
         Slash: 20 # Ratbite - 4 shot to crit, causes quite a bit of bleeding
+        # 14 shots kills a goliath, should be good enough for salv
         Structural: 15
-      armorPenetration: -0.6 # Ratbite - fuck tiders/fauna :godo:
+      armorPenetration: -0.65 # Ratbite - fuck tiders/fauna specifically :godo:
+      woundSevertityMultipliers:
+        Slash: 2 # Ratbite - tider delimbing
 #  - type: StaminaDamageOnCollide
 #    damage: 20            # Ratbite - removed
   - type: TimedDespawn
-    lifetime: 0.15 # Ratbite - Balance, used to be 0.2
+    lifetime: 0.20
   - type: PointLight
     radius: 2
     color: purple

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -83,11 +83,13 @@
     deleteOnCollide: false
     damage:
       types:
-        Heat: 5
-  - type: StaminaDamageOnCollide
-    damage: 20
+        Heat: 10 # Ratbite - Made plasmacutter deal damage instead of stam damage
+        Slash: 5 # Ratbite - 7 shot to crit, causes a slight amount of bleeding, should be fine
+      armorPenetration: -0.2 # Ratbite - make sure it can't be used for armored targets, for balance;
+#  - type: StaminaDamageOnCollide
+#    damage: 20            # Ratbite - removed
   - type: TimedDespawn
-    lifetime: 0.2
+    lifetime: 0.15 # Ratbite - Balance, used to be 0.2
   - type: PointLight
     radius: 2
     color: purple

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -86,7 +86,7 @@
         Heat: 5 # Ratbite - Made plasmacutter deal damage instead of stam damage
         Slash: 10 # Ratbite - 7 shot to crit, causes some bleeding, should be fine
         Structural: 15
-      armorPenetration: -0.2 # Ratbite - hopefully will make bevv not maldPR this into oblivion when cargonia kills them with it :godo:
+      armorPenetration: -0.2 # Ratbite - hopefully will make bevv not maldPR this into oblivion when cargonia kills him with it :godo:
 #  - type: StaminaDamageOnCollide
 #    damage: 20            # Ratbite - removed
   - type: TimedDespawn

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -83,9 +83,10 @@
     deleteOnCollide: false
     damage:
       types:
-        Heat: 10 # Ratbite - Made plasmacutter deal damage instead of stam damage
-        Slash: 5 # Ratbite - 7 shot to crit, causes a slight amount of bleeding, should be fine
-      armorPenetration: -0.2 # Ratbite - make sure it can't be used for armored targets, for balance;
+        Heat: 5 # Ratbite - Made plasmacutter deal damage instead of stam damage
+        Slash: 10 # Ratbite - 7 shot to crit, causes some bleeding, should be fine
+        Structural: 15
+      armorPenetration: -0.2 # Ratbite - hopefully will make bevv not maldPR this into oblivion when cargonia kills them with it :godo:
 #  - type: StaminaDamageOnCollide
 #    damage: 20            # Ratbite - removed
   - type: TimedDespawn

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -84,9 +84,9 @@
     damage:
       types:
         Heat: 5 # Ratbite - Made plasmacutter deal damage instead of stam damage
-        Slash: 10 # Ratbite - 7 shot to crit, causes some bleeding, should be fine
+        Slash: 20 # Ratbite - 4 shot to crit, causes quite a bit of bleeding
         Structural: 15
-      armorPenetration: -0.2 # Ratbite - hopefully will make bevv not maldPR this into oblivion when cargonia kills him with it :godo:
+      armorPenetration: -0.6 # Ratbite - fuck tiders/fauna :godo:
 #  - type: StaminaDamageOnCollide
 #    damage: 20            # Ratbite - removed
   - type: TimedDespawn

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/weapons.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/weapons.yml
@@ -10,11 +10,13 @@
 - type: latheRecipe
   id: WeaponPlasmaCutter
   result: WeaponPlasmaCutterEmpty
-  completetime: 3
+  completetime: 6 # Ratbite
   materials:
     Steel: 500
     Glass: 300
     Plasma: 300
+    Plastic: 300 # Ratbite
+    Gold: 50 # Ratbite
 
 - type: latheRecipe
   id: WeaponPlasmaRifle


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Made plasma cutter deal more damage, and removed its stamina damage
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://discord.com/channels/1386740877837471765/1518681366034645174
It was just a shittier disabler, now its an actual self defence tool.
It now does 5 heat, 10 slash, 15 structural with -20% armor piercing
Any armor with decent slash/heat resist makes it perform way worse, just dont be in a sec voidsuit (it has GARBAGE heat and slash resist) to counter it :godo:
## Technical details
<!-- Summary of code changes for easier review. -->
YAML
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="452" height="407" alt="image" src="https://github.com/user-attachments/assets/823f3913-003b-4d72-8f0b-77bd4b6d5f4a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The plasma cutter now deals slash and structural instead of stamina damage
