### PR TITLE
Fixed SusRat

### DIFF
--- a/Resources/Prototypes/_BRatbite/GameRules/Roundstart.yml
+++ b/Resources/Prototypes/_BRatbite/GameRules/Roundstart.yml
@@ -43,5 +43,101 @@
       min: 300
       max: 700
 
+- type: entity
+  id: SusRatRoundstartAntag
+  parent: BaseGameRule
+  components:
+  - type: SubGamemodes
+    rules:
+    - id: SusRatTraitor
+      prob: 1
+      orGroup: SusRatAntag
+    - id: SusRatChangeling
+      prob: 1
+      orGroup: SusRatAntag
+    - id: SusRatHeretic
+      prob: 1
+      orGroup: SusRatAntag
+
+- type: entity
+  id: SusRatTraitor
+  parent: Traitor
+  components:
+  - type: GameRule
+    minPlayers: 0
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Traitor ]
+      min: 0
+      maxRange:
+        min: 1
+        max: 10
+      playerRatio: 10
+      chaosScore: 150
+      blacklist:
+        components:
+        - CommandStaff
+        - AntagImmune
+        - Changeling
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+      components:
+      - type: CombatTrained
+
+- type: entity
+  id: SusRatChangeling
+  parent: Changeling
+  components:
+  - type: GameRule
+    minPlayers: 0
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    agentName: changeling-roundend-name
+    definitions:
+    - prefRoles: [ Changeling ]
+      min: 0
+      maxRange:
+        min: 1
+        max: 10
+      playerRatio: 10
+      chaosScore: 200
+      jobBlacklist: [ Chaplain ]
+      blacklist:
+        components:
+        - CommandStaff
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleChangeling
+
+- type: entity
+  id: SusRatHeretic
+  parent: Heretic
+  components:
+  - type: GameRule
+    minPlayers: 0
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    agentName: heretic-roundend-name
+    definitions:
+    - prefRoles: [ Heretic ]
+      min: 0
+      maxRange:
+        min: 1
+        max: 10
+      playerRatio: 17
+      chaosScore: 500
+      lateJoinAdditional: true
+      jobBlacklist: [ Chaplain ]
+      blacklist:
+        components:
+        - CommandStaff
+      mindRoles:
+      - MindRoleHeretic
+      components:
+      - type: WeakToHoly
+      - type: CanEnchant
+
 
 #Ratbite end

--- a/Resources/Prototypes/_BRatbite/game_presets.yml
+++ b/Resources/Prototypes/_BRatbite/game_presets.yml
@@ -13,7 +13,7 @@
 - type: gamePreset
   id: SusRat
   name: SusRat
-  showInVote: false #pending highpop rework
+  showInVote: true
   description: The antag could be any one of us...He could be you!
   rules:
     - PermaBrig # Needed

--- a/Resources/Prototypes/_BRatbite/game_presets.yml
+++ b/Resources/Prototypes/_BRatbite/game_presets.yml
@@ -17,9 +17,8 @@
   description: The antag could be any one of us...He could be you!
   rules:
     - PermaBrig # Needed
-    - LowImpactAntagStationScheduler
+    - SusRatRoundstartAntag
     - RatbiteBasicEventsScheduler
-    - SusStationEventScheduler
 
 - type: gamePreset
   id: RatGuide


### PR DESCRIPTION
mrs obama ive done it
ive fixed susrat

Antag conditions:
For every 10 players, 1 more antag is added... Except heretic, that will need 17 players (and adds +1 for every 17 after)
It will use this value as the `max` for a random number between 1-10, to make sure that even highpop can get a low antag amount sometimes, but also fuck you up sometimes too.
There can only ever be EITHER of: traitor, changeling, heretic