### PR TITLE
Move important gear from lockers to loadout

### DIFF
--- a/Content.Server/Objectives/Components/StealConditionComponent.cs
+++ b/Content.Server/Objectives/Components/StealConditionComponent.cs
@@ -76,6 +76,7 @@
 
 using Content.Server.Objectives.Systems;
 using Content.Shared.Objectives;
+using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server.Objectives.Components;
@@ -127,6 +128,12 @@ public sealed partial class StealConditionComponent : Component
     /// </summary>
     [DataField]
     public int CollectionSize;
+
+    /// <summary>
+    /// Ratbite: If this job was not picked by anyone, it will be skipped.
+    /// </summary>
+    [DataField]
+    public ProtoId<JobPrototype>? RequiredJob;
 
     /// <summary>
     /// Help newer players by saying e.g. "steal the chief engineer's advanced magboots"

--- a/Content.Server/Objectives/Systems/StealConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/StealConditionSystem.cs
@@ -93,6 +93,9 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Stacks;
+using Content.Server.Station.Systems;
+using Content.Server.Station.Components;
+using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -105,6 +108,9 @@ public sealed class StealConditionSystem : EntitySystem
     [Dependency] private readonly SharedInteractionSystem _interaction = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly StationJobsSystem _stationJobsSystem = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    private ISawmill _sawmill = default!;
 
     private EntityQuery<ContainerManagerComponent> _containerQuery;
 
@@ -120,6 +126,7 @@ public sealed class StealConditionSystem : EntitySystem
         SubscribeLocalEvent<StealConditionComponent, ObjectiveAssignedEvent>(OnAssigned);
         SubscribeLocalEvent<StealConditionComponent, ObjectiveAfterAssignEvent>(OnAfterAssign);
         SubscribeLocalEvent<StealConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
+        _sawmill = Logger.GetSawmill("system.objectives.steal-condition");
     }
 
     /// start checks of target acceptability, and generation of start values.
@@ -142,6 +149,28 @@ public sealed class StealConditionSystem : EntitySystem
             args.Cancelled = true;
             return;
         }
+
+        // Ratbite start
+
+        if (condition.Comp.RequiredJob is { } requiredJob)
+        {
+            if (_stationSystem.GetOwningStation(args.Mind.OwnedEntity) is not { } owningStation || !TryComp<StationJobsComponent>(owningStation, out var stationJobsComponent))
+            {
+                _sawmill.Warning($"Warning: No owning station found for entity {condition.Owner}");
+                args.Cancelled = true;
+                return;
+            }
+            else
+            {
+                if (!stationJobsComponent.PlayerJobs.Any(p => p.Value.Contains(requiredJob)))
+                {
+                    _sawmill.Debug($"Canceling {condition.Comp.StealGroup.Id} because no jobs are available");
+                    args.Cancelled = true;
+                    return;
+                }
+            }
+        }
+        // Ratbite end
 
         //setup condition settings
         var maxSize = condition.Comp.VerifyMapExistence
@@ -236,7 +265,7 @@ public sealed class StealConditionSystem : EntitySystem
             }
         } while (containerStack.TryPop(out currentManager));
 
-        var result = count / (float)condition.CollectionSize;
+        var result = count / (float) condition.CollectionSize;
         result = Math.Clamp(result, 0, 1);
         return result;
     }

--- a/Resources/Locale/en-US/_BRatbite/loadouts/loadouts.ftl
+++ b/Resources/Locale/en-US/_BRatbite/loadouts/loadouts.ftl
@@ -1,0 +1,11 @@
+loadout-group-captain-hardsuit=Hardsuit
+loadout-group-hos-hardsuit=Hardsuit
+loadout-group-hos-weapon=Primary Weapon
+loadout-group-warden-weapon=Primary Weapon
+loadout-group-warden-glove=Gloves
+loadout-group-cmo-hypospray=Hypospray
+loadout-group-cmo-belt=Belt
+loadout-group-ce-belt=Belt
+loadout-group-ce-rcd=RCD
+loadout-group-rd-hardsuit=Hardsuit
+loadout-group-captain-weapon=Primary Weapon

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/WIP/elkridge.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/WIP/elkridge.yml
@@ -78716,21 +78716,6 @@ entities:
     - type: Transform
       pos: -38.5,-46.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 10801
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-1.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 10802
-    components:
-    - type: Transform
-      pos: -2.5,-37.5
-      parent: 2
 - proto: GoldRing
   entities:
   - uid: 10803

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/amber.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/amber.yml
@@ -101097,21 +101097,6 @@ entities:
     - type: Transform
       pos: 5.5,-91.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 14172
-    components:
-    - type: Transform
-      pos: -26.5,-55.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 14173
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,9.5
-      parent: 2
 - proto: GoldRingDiamond
   entities:
   - uid: 14174

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/bagel.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/bagel.yml
@@ -100048,21 +100048,6 @@ entities:
     - type: Transform
       pos: -59.5,53.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 14783
-    components:
-    - type: Transform
-      pos: -4.5,-2.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 14784
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,-0.5
-      parent: 2
 - proto: GravityGenerator
   entities:
   - uid: 14785

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/barratry.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/barratry.yml
@@ -70239,21 +70239,6 @@ entities:
     - type: Transform
       pos: -68.5,48.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 9358
-    components:
-    - type: Transform
-      pos: -6.5,59.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 9359
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -58.5,64.5
-      parent: 2
 - proto: GravityGenerator
   entities:
   - uid: 9360

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/core.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/core.yml
@@ -97164,21 +97164,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,-1.5
       parent: 22305
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 13837
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 39.5,-30.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 13838
-    components:
-    - type: Transform
-      pos: -11.5,31.5
-      parent: 2
 - proto: GlowstickBase
   entities:
   - uid: 13839

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/elkridge.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/elkridge.yml
@@ -83994,21 +83994,6 @@ entities:
     - type: Transform
       pos: -38.5,-46.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 11817
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -28.5,-1.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 11818
-    components:
-    - type: Transform
-      pos: 0.5,-36.5
-      parent: 2
 - proto: GlockenspielInstrument
   entities:
   - uid: 5

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/loop.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/loop.yml
@@ -70800,21 +70800,6 @@ entities:
     - type: Transform
       pos: -80.5,72.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 10559
-    components:
-    - type: Transform
-      pos: -16.5,70.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 10560
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -38.5,40.5
-      parent: 2
 - proto: GravityGenerator
   entities:
   - uid: 10561

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/marathon.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/marathon.yml
@@ -92285,20 +92285,6 @@ entities:
     - type: Transform
       pos: 43.5,29.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 13849
-    components:
-    - type: Transform
-      pos: -21.5,34.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 13850
-    components:
-    - type: Transform
-      pos: -22.5,53.5
-      parent: 2
 - proto: GlowstickRed
   entities:
   - uid: 13851

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/oasis.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/oasis.yml
@@ -126714,20 +126714,6 @@ entities:
     - type: Transform
       pos: -42.5,47.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 14662
-    components:
-    - type: Transform
-      pos: 39.5,11.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 14663
-    components:
-    - type: Transform
-      pos: 37.5,-39.5
-      parent: 2
 - proto: GlowstickYellow
   entities:
   - uid: 28395

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/omega.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/omega.yml
@@ -56145,20 +56145,6 @@ entities:
     - type: Transform
       pos: -13.5,11.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 8371
-    components:
-    - type: Transform
-      pos: -13.5,25.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 8372
-    components:
-    - type: Transform
-      pos: -23.5,24.5
-      parent: 2
 - proto: GravityGenerator
   entities:
   - uid: 8373

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/packed.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/packed.yml
@@ -63257,22 +63257,6 @@ entities:
     - type: Transform
       pos: 89.5,-3.5
       parent: 2
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 9295
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 31.5,39.5
-      parent: 2
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 9296
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 45.5,23.5
-      parent: 2
 - proto: GlowstickRed
   entities:
   - uid: 9297

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/reach.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/reach.yml
@@ -16520,6 +16520,13 @@ entities:
       parent: 2
     - type: ActiveListener
       range: 2
+- proto: WeaponEnergyShotgun
+  entities:
+  - uid: 2443
+    components:
+    - type: Transform
+      pos: 18.5,-2.5
+      parent: 2
 - proto: WeaponPistolCHIMP
   entities:
   - uid: 2444

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/reach.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/reach.yml
@@ -16520,13 +16520,6 @@ entities:
       parent: 2
     - type: ActiveListener
       range: 2
-- proto: WeaponEnergyShotgun
-  entities:
-  - uid: 2443
-    components:
-    - type: Transform
-      pos: 18.5,-2.5
-      parent: 2
 - proto: WeaponPistolCHIMP
   entities:
   - uid: 2444

--- a/Resources/Maps/_BRatbite/Ratbite_Supported/snowball.yml
+++ b/Resources/Maps/_BRatbite/Ratbite_Supported/snowball.yml
@@ -79471,20 +79471,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 51.5,40.5
       parent: 1
-- proto: GlassBoxLaserFilled
-  entities:
-  - uid: 14959
-    components:
-    - type: Transform
-      pos: 21.5,43.5
-      parent: 1
-- proto: GlassBoxLawbringerFilled
-  entities:
-  - uid: 11048
-    components:
-    - type: Transform
-      pos: 42.5,30.5
-      parent: 1
 - proto: GravityGenerator
   entities:
   - uid: 6756

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -193,9 +193,9 @@
  #  - id: CaptainIDCard
     - id: CigarGoldCase
       prob: 0.25
-    - id: ClothingBeltSheathFilled
+    # - id: ClothingBeltSheathFilled # Ratbite: Move to loadout
     - id: ClothingHeadsetAltCommand
-    - id: ClothingOuterArmorCaptainCarapace
+    # - id: ClothingOuterArmorCaptainCarapace # Ratbite: Armor is OP and should not be in the locker, captain should use the in their loadout
     - id: CommsComputerCircuitboard
     - id: DoorRemoteCustom
     - id: MedalCase
@@ -219,14 +219,14 @@
     children:
     - !type:NestedSelector
       tableId: LockerFillCaptainNoLaser
-    - id: WeaponAntiqueLaser
+    # - id: WeaponAntiqueLaser # Ratbite: Move to loadout
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
   id: FillCaptainHardsuit
   table: !type:AllSelector
     children:
-    - id: UndeterminedVoidsuitCaptain # Goobstation - Modsuit Update
+    # - id: UndeterminedVoidsuitCaptain # Goobstation - Modsuit Update (Ratbite: Move to loadout)
     - id: ClothingMaskGasCaptain
     - id: JetpackCaptainFilled
     - id: OxygenTankFilled
@@ -316,7 +316,7 @@
     - id: BoxEncryptionKeyEngineering
     - id: CigarCase
       prob: 0.15
-    - id: ClothingBeltChiefEngineerFilled
+    # - id: ClothingBeltChiefEngineerFilled # (Ratbite move to loadout)
     - id: ClothingEyesGlassesMeson
     - id: ClothingHandsGlovesColorYellow
     - id: ClothingHeadsetAltEngineering
@@ -337,7 +337,7 @@
  #  - id: CartridgeRocketSingularityBuster
  #  - id: WeaponLauncherSingularityBuster
     - id: MachinePowerTransmissionLaserFlatpack
-    - id: RCDRechargingCE
+    # - id: RCDRechargingCE # (Ratbite move to loadout)
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -345,8 +345,8 @@
   table: !type:AllSelector
     children:
     - id: ClothingMaskGasAtmos
-    - id: ClothingOuterHardsuitEngineeringWhite
-    - id: ClothingShoesBootsMagAdv
+    # - id: ClothingOuterHardsuitEngineeringWhite # (Ratbite move to loadout)
+    # - id: ClothingShoesBootsMagAdv # (Ratbite move to loadout)
     - id: JetpackVoidFilled
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
@@ -392,7 +392,7 @@
     - id: ClothingMaskSterile
     - id: DoorRemoteMedical
     # - id: HandheldCrewMonitor # Goobstation - in webbing
-    - id: Hypospray
+    # - id: Hypospray # (Ratbite, move to loadout)
     - id: MedicalTechFabCircuitboard
     - id: ComputerCargoRequestMedicalFlatpack # Goobstation
     - id: MedkitFilled
@@ -407,7 +407,7 @@
     - id: MedTekCartridge
     - id: SyringeGun
  #  - id: BoxSyringePax
-    - id: ClothingBeltMilitaryWebbingCMOFilled
+    # - id: ClothingBeltMilitaryWebbingCMOFilled # (Ratbite, move to loadout)
     - id: ClothingBackpackDuffelSurgeryFilled
     # Shitmed
     - id: MedicalBiofabricatorFlatpack
@@ -422,7 +422,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingMaskBreathMedical
-    - id: ClothingOuterHardsuitMedical
+    # - id: ClothingOuterHardsuitMedical # (Ratbite, move to loadout)
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
 
@@ -483,7 +483,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingMaskBreath
-    - id: UndeterminedVoidsuitRD
+    # - id: UndeterminedVoidsuitRD # Ratbite: Move to loadout
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
 
@@ -546,7 +546,7 @@
   table: !type:AllSelector
     children:
     - id: ClothingMaskGasSwat
-    - id: UndeterminedVoidsuitHeadOfSecurity # Goob edit
+    # - id: UndeterminedVoidsuitHeadOfSecurity # Goob edit (Ratbite: move to loadouts)
     - id: JetpackSecurityFilled
     - id: OxygenTankFilled
     - id: NitrogenTankFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -109,7 +109,7 @@
     - id: ClothingBeltSecurityFilled
     - id: Flash
     - id: ClothingEyesGlassesSecurity
-    - id: ClothingHandsGlovesCombat
+    # - id: ClothingHandsGlovesCombat (Ratbite, move to loadouts)
     - id: ClothingShoesBootsJack
     - id: ClothingOuterCoatWarden
     - id: ClothingOuterWinterWarden
@@ -122,8 +122,8 @@
     - id: RemoteSignaller
       amount: 2
     - id: Binoculars
-    - id: WeaponEnergyShotgun # Goobstation
-    - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts
+    # - id: WeaponEnergyShotgun # Goobstation (Ratbite, move to loadouts)
+    # - id: ClothingHandsGlovesKravMaga # Goobstation - Martial Arts (Ratbite, move to loadouts)
     - id: BoxLethalInjection # Goobstation
     - id: ClothingHeadsetAltWarden # Goobstation
     - id: Multitool # Goobstation

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1025,14 +1025,16 @@
 - type: loadoutGroup
   id: ChiefEngineerOuterClothing
   name: loadout-group-chief-engineer-outerclothing
-  minLimit: 0
+  minLimit: 1
   loadouts:
-  - ChiefEngineerWintercoat
+  # - ChiefEngineerWintercoat Ratbite: Make sure CE's take their hardsuit
+  - CEHardsuit
 
 - type: loadoutGroup
   id: ChiefEngineerShoes
   name: loadout-group-chief-engineer-shoes
   loadouts:
+  - CEMagboots
   - BrownShoes
   - EngineeringWinterBoots
 
@@ -1487,10 +1489,13 @@
 - type: loadoutGroup
   id: ChiefMedicalOfficerOuterClothing
   name: loadout-group-chief-medical-officer-outerclothing
-  minLimit: 0
+  minLimit: 1
   loadouts:
-  - ChiefMedicalOfficerLabCoat
-  - ChiefMedicalOfficerWintercoat
+  # - ChiefMedicalOfficerLabCoat
+  # - ChiefMedicalOfficerWintercoat
+  - CMOHardsuit # Ratbite: Make sure CMO's select their hardsuit (They
+                # can take the labcoat and wintercoat from the dresser
+                # later
 
 - type: loadoutGroup
   id: ChiefMedicalOfficerNeck

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -124,7 +124,11 @@
   - CaptainJumpsuit
   - CaptainMask # Goobstation - Lollypops!
   - CaptainBackpack
+  # Ratbite loadouts:
   - CaptainBelt # Ratbite - Captain Powergaming
+  - CaptainWeapon
+  - CaptainHardsuit
+  # End ratbite loadouts
   - CaptainOuterClothing
   - Survival
   - Trinkets
@@ -465,6 +469,8 @@
   - ChiefEngineerNeck
   - ChiefEngineerOuterClothing
   - ChiefEngineerShoes
+  - CERCD
+  - CEBelt
   - SurvivalExtended
   - Trinkets
   - Animals
@@ -536,6 +542,7 @@
   - ResearchDirectorJumpsuit
   - ScientistBackpack
   - ResearchDirectorOuterClothing
+  - RDHardsuit # Ratbite
   - ScientistGloves
   - ResearchDirectorShoes
   - Glasses
@@ -594,8 +601,12 @@
   - HeadofSecurityNeck
   - HeadofSecurityJumpsuit
   - SecurityBackpack
-  - SecuritySidearm #Ratbite
-  - SecurityAmmo #Ratbite
+  # Ratbite loadouts start
+  - SecuritySidearm
+  - SecurityAmmo
+  - HosWeapon
+  - HosHardsuit
+  # Ratbite loadouts end
   - SecurityMelee # Goobstation
   - SecurityBelt
   - HeadofSecurityOuterClothing
@@ -617,8 +628,12 @@
   - WardenHead
   - WardenJumpsuit
   - SecurityBackpack
-  - SecuritySidearm #Ratbite
-  - SecurityAmmo #Ratbite
+  # Ratbite loadouts start
+  - SecuritySidearm
+  - SecurityAmmo
+  - WardenWeapon
+  - WardenGlove
+  # Ratbite loadouts end
   - SecurityMelee # Goobstation
   - SecurityNeck
   - SecurityBelt
@@ -712,6 +727,8 @@
   - SurvivalMedical
   - Trinkets
   - Animals
+  - CMOBelt
+  - CMOHypospray
   - GroupSpeciesBreathToolMedical
   # Goobstation - EE Plasmeme Change.
   - ChiefMedicalOfficerEnvirohelm

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -123,12 +123,12 @@
     # CERocketLauncherStealObjective: 1
     CorgiMeatStealObjective: 1
     ClipboardStealObjective: 1
-    CaptainGunStealObjective: 0.5
+    # CaptainGunStealObjective: 0.5
     CaptainJetpackStealObjective: 0.5
     HandTeleporterStealObjective: 0.5
-    EnergyShotgunStealObjective: 0.5
+    # EnergyShotgunStealObjective: 0.5
     StealSupermatterSliverObjective: 0.5 # Goobstation - supermatter
-    LawbringerStealObjective: 0.5 # Goobstation
+    # LawbringerStealObjective: 0.5 # Goobstation
     GeminiProjectorStealObjective: 0.5 # Goobstation
     ExecutiveBriefcaseStealObjective: 0.5 # Goobstation
     JusticeStealObjective: 0.5 # Goobstation

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -249,6 +249,7 @@
   components:
   - type: StealCondition
     stealGroup: Hypospray
+    requiredJob: ChiefMedicalOfficer
 
 #- type: entity # Goobstation - made this public
 #  parent: BaseCMOStealObjective
@@ -275,6 +276,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitRd
+    requiredJob: ResearchDirector
   - type: Objective
     # This item must be worn or stored in a slowing duffelbag, very hard to hide.
     difficulty: 3
@@ -288,18 +290,19 @@
 
 ## warden
 
-- type: entity
-  parent: BaseTraitorStealObjective
-  id: EnergyShotgunStealObjective
-  components:
-  - type: Objective
-    # Warden will have this on them a lot of the time so..
-    difficulty: 3
-  - type: NotJobRequirement
-    job: Warden # Goob edit
-  - type: StealCondition
-    stealGroup: WeaponEnergyShotgun
-    owner: job-name-warden # Goob edit
+# Ratbite: Energy shotgun is not guaranteed to spawn (Wardens can pick enforcer)
+#- type: entity
+#  parent: BaseTraitorStealObjective
+#  id: EnergyShotgunStealObjective
+#  components:
+#  - type: Objective
+#    # Warden will have this on them a lot of the time so..
+#    difficulty: 3
+#  - type: NotJobRequirement
+#    job: Warden # Goob edit
+#  - type: StealCondition
+#    stealGroup: WeaponEnergyShotgun
+#    owner: job-name-warden # Goob edit
 
 ## ce
 
@@ -319,6 +322,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingShoesBootsMagAdv
+    requiredJob: ChiefEngineer
 
 ## qm
 
@@ -383,13 +387,14 @@
   - type: StealCondition
     stealGroup: JetpackCaptainFilled
 
-- type: entity
-  parent: BaseCaptainObjective
-  id: CaptainGunStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: WeaponAntiqueLaser
-    owner: job-name-captain
+# Ratbite: Antique Laser is not guaranteed to spawn
+#- type: entity
+#  parent: BaseCaptainObjective
+#  id: CaptainGunStealObjective
+#  components:
+#  - type: StealCondition
+#    stealGroup: WeaponAntiqueLaser
+#    owner: job-name-captain
 
 - type: entity
   parent: BaseCaptainObjective

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -184,7 +184,7 @@
     id: CEPDA
     eyes: ClothingEyesGlassesMeson
     ears: ClothingHeadsetAltEngineering # Goobstation
-    belt: ClothingBeltUtilityEngineering
+    # belt: ClothingBeltUtilityEngineering # Ratbite, moved to loadout
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -184,7 +184,7 @@
     id: CMOPDA
     ears: ClothingHeadsetAltMedical # Goobstation
     eyes: ClothingEyesGlassesMed # Goobstation
-    belt: ClothingBeltMedicalFilled
+    # belt: ClothingBeltMedicalFilled # Ratbite, they now have chestrig in their loadouts
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Command/captain.yml
@@ -1,0 +1,28 @@
+# Move import equipment to loadout
+
+# Captain
+- type: loadout
+  id: WeaponAntiqueLaser
+  storage:
+    back:
+    - WeaponAntiqueLaser
+
+- type: loadout
+  id: CaptainSaber
+  equipment:
+    belt: ClothingBeltSheathFilled
+  
+- type: loadout
+  id: Enforcer
+  dummyEntity: WeaponShotgunEnforcer
+  storage:
+    back:
+    - WeaponShotgunEnforcer
+    - BoxLethalshot
+
+- type: loadout
+  id: CaptainHardsuitSelector
+  storage:
+    back:
+    - UndeterminedVoidsuitCaptain
+  

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Engineering/chief_engineer.yml
@@ -1,0 +1,20 @@
+- type: loadout
+  id: CEHardsuit
+  equipment:
+    outerClothing: ClothingOuterHardsuitEngineeringWhite
+
+- type: loadout
+  id: CEBelt
+  equipment:
+    belt: ClothingBeltChiefEngineerFilled
+
+- type: loadout
+  id: CERCD
+  storage:
+    back:
+    - RCDRechargingCE
+
+- type: loadout
+  id: CEMagboots
+  equipment:
+    shoes: ClothingShoesBootsMagAdv

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -1,0 +1,15 @@
+- type: loadout
+  id: CMOChestRig
+  equipment:
+    belt: ClothingBeltMilitaryWebbingCMOFilled
+
+- type: loadout
+  id: CMOHypospray
+  storage:
+    back:
+    - Hypospray
+
+- type: loadout
+  id: CMOHardsuit
+  equipment:
+    outerClothing: ClothingOuterHardsuitMedical

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Science/research_director.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: RDHardsuit
+  storage:
+    back:
+    - UndeterminedVoidsuitRD

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Security/head_of_security.yml
@@ -1,0 +1,14 @@
+- type: loadout
+  id: HosLawbringer
+  storage:
+    back:
+    - WeaponEnergyGunLawbringer
+
+- type: loadout
+  id: HosHardsuitSelector
+  storage:
+    back:
+    - UndeterminedVoidsuitHeadOfSecurity
+
+# We intentionally keep the energy sword in the locker
+# Otherwise nobody would select it, because it's only good against permas

--- a/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/Jobs/Security/warden.yml
@@ -1,0 +1,10 @@
+- type: loadout
+  id: KravMagaGloves
+  equipment:
+    gloves: ClothingHandsGlovesKravMaga
+
+- type: loadout
+  id: WardenEnergyShotgun
+  storage:
+    back:
+    - WeaponEnergyShotgun

--- a/Resources/Prototypes/_BRatbite/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_BRatbite/Loadouts/loadout_groups.yml
@@ -97,6 +97,22 @@
   - SecurityWebbing
   - SecurityJudoBelt
   - MedicalBelt
+  - CaptainSaber
+
+- type: loadoutGroup
+  id: CaptainWeapon
+  name: loadout-group-captain-weapon
+  maxLimit: 1
+  loadouts:
+  - WeaponAntiqueLaser
+  - Enforcer
+
+- type: loadoutGroup
+  id: CaptainHardsuit
+  name: loadout-group-captain-hardsuit
+  maxLimit: 1
+  loadouts:
+  - CaptainHardsuitSelector
 
 #endregion
 
@@ -161,4 +177,72 @@
   - EngiGuardInsideJumpsuit
 #endregion
 
+# region HoS
+- type: loadoutGroup
+  id: HosHardsuit
+  name: loadout-group-hos-hardsuit
+  loadouts:
+  - HosHardsuitSelector
+
+- type: loadoutGroup
+  id: HosWeapon
+  name: loadout-group-hos-weapon
+  loadouts:
+  - HosLawbringer
+  - Enforcer
+# endregion
+
+# region Warden
+- type: loadoutGroup
+  id: WardenWeapon
+  name: loadout-group-warden-weapon
+  loadouts:
+  - WardenEnergyShotgun
+  - Enforcer
+
+- type: loadoutGroup
+  id: WardenGlove
+  name: loadout-group-warden-glove
+  loadouts:
+  - KravMagaGloves
+  - CombatGloves
+  
+# endregion
+
+# region CMO
+- type: loadoutGroup
+  id: CMOHypospray
+  name: loadout-group-cmo-hypospray
+  loadouts:
+  - CMOHypospray
+
+- type: loadoutGroup
+  id: CMOBelt
+  name: loadout-group-cmo-belt
+  loadouts:
+  - CMOChestRig
+# end region
+
+# region CE
+- type: loadoutGroup
+  id: CEBelt
+  name: loadout-group-ce-belt
+  loadouts:
+  - CEBelt
+
+- type: loadoutGroup
+  id: CERCD
+  name: loadout-group-ce-rcd
+  loadouts:
+  - CERCD
+
+# end region
+# region RD
+- type: loadoutGroup
+  id: RDHardsuit
+  name: loadout-group-rd-hardsuit
+  loadouts:
+  - RDHardsuit
+# end region
 #endregion
+

--- a/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Objectives/changeling.yml
@@ -146,6 +146,7 @@
   components:
   - type: StealCondition
     stealGroup: Hypospray
+    requiredJob: ChiefMedicalOfficer # Ratbite
 
 - type: entity
   parent: LingCMOStealObjective
@@ -172,6 +173,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitRd
+    requiredJob: ResearchDirector # Ratbite
 
 - type: entity
   parent: LingRDStealObjective
@@ -182,15 +184,16 @@
 
 ## warden
 
-- type: entity
-  parent: ChangelingStealObjective
-  id: LingEnergyShotgunStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Warden # Goob edit
-  - type: StealCondition
-    stealGroup: WeaponEnergyShotgun
-    owner: job-name-warden # Goob edit
+# Ratbite: Energy shotgun is not guaranteed to spawn (Wardens can pick enforcer)
+#- type: entity
+#  parent: ChangelingStealObjective
+#  id: LingEnergyShotgunStealObjective
+#  components:
+#  - type: NotJobRequirement
+#    job: Warden # Goob edit
+#  - type: StealCondition
+#    stealGroup: WeaponEnergyShotgun
+#    owner: job-name-warden # Goob edit
 
 ## ce
 
@@ -210,6 +213,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingShoesBootsMagAdv
+    requiredJob: ChiefEngineer
 
 ## qm
 
@@ -269,13 +273,14 @@
   - type: StealCondition
     stealGroup: JetpackCaptainFilled
 
-- type: entity
-  parent: LingCaptainObjective
-  id: LingCaptainGunStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: WeaponAntiqueLaser
-    owner: job-name-captain
+# Ratbite: Antique laser is not guaranteed to spawn (Captains can pick enforcer instead)
+#- type: entity
+#  parent: LingCaptainObjective
+#  id: LingCaptainGunStealObjective
+#  components:
+#  - type: StealCondition
+#    stealGroup: WeaponAntiqueLaser
+#    owner: job-name-captain
 
 - type: entity
   parent: LingCaptainObjective

--- a/Resources/Prototypes/_Goobstation/Objectives/corporageagent.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/corporageagent.yml
@@ -166,6 +166,7 @@
   components:
   - type: StealCondition
     stealGroup: Hypospray
+    requiredJob: ChiefMedicalOfficer
 
 #- type: entity # Goobstation - made this public
 #  parent: BaseCMOStealObjective
@@ -192,6 +193,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingOuterHardsuitRd
+    requiredJob: ResearchDirector
   - type: Objective
     # This item must be worn or stored in a slowing duffelbag, very hard to hide.
     difficulty: 3
@@ -205,18 +207,18 @@
 
 ## warden
 
-- type: entity
-  parent: BaseCorporateStealObjective
-  id: CorporateEnergyShotgunStealObjective
-  components:
-  - type: Objective
-    # Warden will have this on them a lot of the time so..
-    difficulty: 3
-  - type: NotJobRequirement
-    job: Warden # Goob edit
-  - type: StealCondition
-    stealGroup: WeaponEnergyShotgun
-    owner: job-name-warden # Goob edit
+# - type: entity
+#   parent: BaseCorporateStealObjective
+#   id: CorporateEnergyShotgunStealObjective
+#   components:
+#   - type: Objective
+#     # Warden will have this on them a lot of the time so..
+#     difficulty: 3
+#   - type: NotJobRequirement
+#     job: Warden # Goob edit
+#   - type: StealCondition
+#     stealGroup: WeaponEnergyShotgun
+#     owner: job-name-warden # Goob edit
 
 ## ce
 
@@ -236,6 +238,7 @@
   components:
   - type: StealCondition
     stealGroup: ClothingShoesBootsMagAdv
+    requiredJob: ChiefEngineer
 
 ## qm
 
@@ -300,13 +303,13 @@
   - type: StealCondition
     stealGroup: JetpackCaptainFilled
 
-- type: entity
-  parent: CorporateBaseCaptainObjective
-  id: CorporateCaptainGunStealObjective
-  components:
-  - type: StealCondition
-    stealGroup: WeaponAntiqueLaser
-    owner: job-name-captain
+# - type: entity
+#   parent: CorporateBaseCaptainObjective
+#   id: CorporateCaptainGunStealObjective
+#   components:
+#   - type: StealCondition
+#     stealGroup: WeaponAntiqueLaser
+#     owner: job-name-captain
 
 - type: entity
   parent: CorporateBaseCaptainObjective
@@ -390,18 +393,18 @@
     objectiveNoOwnerText: objective-condition-steal-smsliver-title
     descriptionText: objective-condition-steal-smsliver-description
 
-- type: entity
-  parent: BaseCorporateStealObjective
-  id: CorporateLawbringerStealObjective
-  components:
-  - type: Objective
-    # HoS will have this on them a lot of the time so..
-    difficulty: 3
-  - type: NotJobRequirement
-    job: HeadOfSecurity
-  - type: StealCondition
-    stealGroup: WeaponEnergyGunLawbringer
-    owner: job-name-hos
+# - type: entity
+#   parent: BaseCorporateStealObjective
+#   id: CorporateLawbringerStealObjective
+#   components:
+#   - type: Objective
+#     # HoS will have this on them a lot of the time so..
+#     difficulty: 3
+#   - type: NotJobRequirement
+#     job: HeadOfSecurity
+#   - type: StealCondition
+#     stealGroup: WeaponEnergyGunLawbringer
+#     owner: job-name-hos
 
 - type: entity
   parent: CorporateBaseCMOStealObjective

--- a/Resources/Prototypes/_Goobstation/Objectives/corporateagentgroups.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/corporateagentgroups.yml
@@ -26,12 +26,12 @@
     # CorporateCERocketLauncherStealObjective: 1
     CorporateCorgiMeatStealObjective: 1
     CorporateClipboardStealObjective: 1
-    CorporateCaptainGunStealObjective: 0.5
+    # CorporateCaptainGunStealObjective: 0.5
     CorporateCaptainJetpackStealObjective: 0.5
     CorporateHandTeleporterStealObjective: 0.5
-    CorporateEnergyShotgunStealObjective: 0.5
+    # CorporateEnergyShotgunStealObjective: 0.5
     CorporateStealSupermatterSliverObjective: 0.5 # Goobstation - supermatter
-    CorporateLawbringerStealObjective: 0.5 # Goobstation specific
+    # CorporateLawbringerStealObjective: 0.5 # Goobstation specific
     CorporateGeminiProjectorStealObjective: 0.5 # Goobstation specific
 
 - type: weightedRandom

--- a/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/objectiveGroups.yml
@@ -22,10 +22,10 @@
     LingMagbootsStealObjective: 1
     LingCorgiMeatStealObjective: 1
     LingClipboardStealObjective: 1
-    LingCaptainGunStealObjective: 1
+    # LingCaptainGunStealObjective: 1
     LingCaptainJetpackStealObjective: 1
     LingHandTeleporterStealObjective: 1
-    LingEnergyShotgunStealObjective: 1
+    # LingEnergyShotgunStealObjective: 1
     LingStealSupermatterSliverObjective: 1
     ## all equal chance regardless of risk - put those abilities to use
 

--- a/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
+++ b/Resources/Prototypes/_Goobstation/Objectives/traitor.yml
@@ -83,18 +83,18 @@
     objectiveNoOwnerText: objective-condition-steal-smsliver-title
     descriptionText: objective-condition-steal-smsliver-description
 
-- type: entity
-  parent: BaseTraitorStealObjective
-  id: LawbringerStealObjective
-  components:
-  - type: Objective
-    # HoS will have this on them a lot of the time so..
-    difficulty: 3
-  - type: NotJobRequirement
-    job: HeadOfSecurity
-  - type: StealCondition
-    stealGroup: WeaponEnergyGunLawbringer
-    owner: job-name-hos
+# - type: entity
+#   parent: BaseTraitorStealObjective
+#   id: LawbringerStealObjective
+#   components:
+#   - type: Objective
+#     # HoS will have this on them a lot of the time so..
+#     difficulty: 3
+#   - type: NotJobRequirement
+#     job: HeadOfSecurity
+#   - type: StealCondition
+#     stealGroup: WeaponEnergyGunLawbringer
+#     owner: job-name-hos
 
 - type: entity
   parent: BaseTraitorStealObjective


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Move important gear from lockers to loadout. The moved gear is as follows:
### Captain
- Hardsuit selector, Carapace, sabre sheat, laser gun moved to loadout
- The laser gun casing was also removed for every ratbite map
- Added the option for the captain to take an enforcer instead of the laser gun.
### Head of Security
- Hardsuit selector, lawbringer moved to loadouts (The hos saber was intentionally left in the locker, as it's very situational and few people would pick it instead of other belts)
- Removed lawbringer casing from every ratbite map
- Added the option for the HoS to optionally take enforcer instead of lawbringer
### Warden
- Energy shotgun, both gloves were moved to loadout
- Added the option for the warden to optionally take enforcer instead of energy shotgun
### CMO
- Hypospray, Hardsuit, chestrig moved to loadout
### Chief Engineer
- Experimental RCD, Hardsuit, advanced magboots, belt moved to loadout
### RD
- Hardsuit moved to loadout.

For steal objectives that targeted these items, a new check was added that skips them and picks a different objective if no one picked the job (This checks the actual jobs, acting heads do not count towards this).
 Weapons objectives from HoS, warden and Captain were removed because they might pick enforcer instead of their old weapon
## Why / Balance

This should make people less likely to break into heads' lockers to steal gear, as previously it would be common to see prisoners escape at the start of the round and take the energy shotgun/captain's weapons and take over the station because even if the head would arrive they didn't have any option to fight back (As they didn't have their weapon)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="792" height="607" alt="image" src="https://github.com/user-attachments/assets/2b1a3279-50df-480e-925c-959b4faab3e9" />
<img width="797" height="524" alt="image" src="https://github.com/user-attachments/assets/34852e41-f5e5-4087-a6f4-c8ce95eccb2b" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Important gear will now be selectable in the loadouts instead of spawning in lockers
