### PR TITLE
Inject insane people ketamine when they spawn

### DIFF
--- a/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
@@ -163,13 +163,7 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         var newMind = _mind.CreateMind(data!.UserId, character.Name);
         _mind.SetUserId(newMind, data.UserId);
 
-        var jobId = "Prisoner";
-        if (inpatient)
-        {
-            jobId = _prototypeManager.HasIndex<JobPrototype>("SanitariumPatient")
-                ? "SanitariumPatient"
-                : "Prisoner";
-        }
+        var jobId = inpatient ? "SanitariumPatient" : "Prisoner";
 
         _playTimeTrackings.PlayerRolesChanged(player);
 
@@ -178,8 +172,9 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
 
         spawnLoc = GetSpawnLocation(jobId);
 
-        if (inpatient && jobId == "SanitariumPatient" && spawnLoc == null)
+        if (inpatient && spawnLoc == null)
         {
+            _sawmill.Warning("No spawn loc found for sanitarium patient");
             // If no sanitarium spawnpoint exists, use Prisoner spawn routing instead of station fallback.
             jobId = "Prisoner";
             spawnLoc = GetSpawnLocation(jobId);
@@ -191,7 +186,7 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         {
             mobMaybe = _stationSpawning.SpawnPlayerMob(
                 spawnLoc.Value,
-            jobId,
+                jobId,
                 character,
                 station);
         }

--- a/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
@@ -31,6 +31,10 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using Content.Server._BRatbite.CryoSickness;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Goobstation.Maths.FixedPoint;
 
 namespace Content.Server._BRatbite.PermaBrig;
 
@@ -60,6 +64,10 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
     [Dependency] private readonly CryoSicknessSystem _cryoSicknessSystem = default!;
     [Dependency] private readonly SharedCuffableSystem _cuffableSystem = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
+    private readonly ProtoId<ReagentPrototype> _ketamine = "Ketamine";
+    // This is the equivalent of 10 minutes of sedation
+    private readonly FixedPoint2 _amountToInject = 2f;
 
     public HashSet<ICommonSession> PermaIndividuals = new();
     public Dictionary<ICommonSession, (TimeSpan, TimeSpan)> PermaIndividualJoinedTime = new();
@@ -201,9 +209,7 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         // Inpatients should always receive a straightjacket, regardless of spawn path.
         if (inpatient)
         {
-            var cuffs = _ent.SpawnEntity("ClothingOuterStraightjacket", Transform(mob).Coordinates);
-            var comp = EnsureComp<CuffableComponent>(mob);
-            _cuffableSystem.TryAddNewCuffs(mob, mob, cuffs, comp);
+            CuffAndInjectWithKetamine(mob);
         }
 
         var brigTime = _permaBrigManager.GetBrigTime(player.UserId);
@@ -258,6 +264,18 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         _stationRecords.OnPlayerSpawn(aev);
         _trait.ApplyTraits(mob, character);
         _cryoSicknessSystem.ApplyComponent(mob);
+    }
+
+    private void CuffAndInjectWithKetamine(EntityUid prisoner)
+    {
+        var cuffs = _ent.SpawnEntity("ClothingOuterStraightjacket", Transform(prisoner).Coordinates);
+        var cuffableComp = EnsureComp<CuffableComponent>(prisoner);
+        _cuffableSystem.TryAddNewCuffs(prisoner, prisoner, cuffs, cuffableComp);
+        if (!TryComp<BloodstreamComponent>(prisoner, out var bloodstream)) return;
+        if (!_solutionContainerSystem.ResolveSolution(prisoner, bloodstream.ChemicalSolutionName, ref bloodstream.ChemicalSolution))
+            return;
+
+        _solutionContainerSystem.TryAddReagent(bloodstream.ChemicalSolution.Value, new ReagentId(_ketamine, null), _amountToInject, out _);
     }
 
     // private void OnRoundEnd(RoundEndMessageEvent ev) Auto decrease of perma sentence not yet implemented


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Inject insane people with 2u (Equivalent of 10 minutes of sedation) of ketamine when they spawn

## Why / Balance

Insane people are probably people who break grace and have a high probability of hiding in a corner and removing the straight jacket when medbay/sec are still making preparations, this gives them a 10 minute grace essentially  
## Technical details
I also cleaned up the logic slightly because the "SanitariumPatient" is defined in the yaml and it's never going to be not defined, unlike the spawnpoints which are defined per map and have a possibility of being null

## Media
<img width="699" height="488" alt="image" src="https://github.com/user-attachments/assets/7cdbfaee-8250-44a0-985f-df02309fbf97" />

(This image has ketamine injection amount set to 15 for demonstration purposes, but the actual amount is 2u)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Inject insane people with ketamine round start
