### PR TITLE
applied base lag fixes that were requested

### DIFF
--- a/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
+++ b/Content.Server/_BRatbite/Weapons/Ranged/CombatTrainedSystem.cs
@@ -34,6 +34,9 @@ public sealed partial class CombatTrainedSystem : EntitySystem
 
     private void OnShutdownComp(Entity<CombatTrainedComponent> ent, ref ComponentShutdown args)
     {
+        if (TerminatingOrDeleted(ent.Owner))
+            return;
+
         AddComp<CombatUntrainedComponent>(ent.Owner);
     }
 

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -377,7 +377,7 @@ public sealed partial class CCVars
     ///     but may cause lag during round end with very high player counts.
     /// </summary>
     public static readonly CVarDef<bool> RoundEndPVSOverrides =
-        CVarDef.Create("game.round_end_pvs_overrides", true, CVar.SERVERONLY);
+        CVarDef.Create("game.round_end_pvs_overrides", false, CVar.SERVERONLY);
 
     /// <summary>
     ///     If true, players can place objects onto tabletop games like chess boards.

--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
@@ -1,5 +1,6 @@
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Actions;
+using Content.Shared.StatusEffect;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -18,7 +19,7 @@ public sealed partial class CryoSicknessComponent : Component
     public EntProtoId Action = "ActionShakeAwake";
 
     [DataField]
-    public EntProtoId Effect = "Pacified";
+    public ProtoId<StatusEffectPrototype> Effect = "Pacified";
 
     [DataField]
     public float DamageResistance = 0.6f;

--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
@@ -7,7 +7,7 @@ using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffectNew;
+using Content.Shared.StatusEffect;
 using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -32,13 +32,13 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<CryoSicknessComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<CryoSicknessComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<CryoSicknessComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<CryoSicknessComponent, DamageModifyEvent>(OnDamageModifyEvent);
         SubscribeLocalEvent<CryoSicknessComponent, DamageChangedEvent>(OnDamageChange);
         SubscribeLocalEvent<CryoSicknessComponent, MindAddedMessage>(OnPlayerAttach);
         SubscribeLocalEvent<CryoSicknessComponent, PlayerAttachedEvent>(OnPlayerAttach);
         SubscribeLocalEvent<CryoSicknessComponent, ShakeAwakeEvent>(OnShakeAwake);
-        SubscribeLocalEvent<CryoSicknessComponent, BeforePacifiedAttackEvent>(OnBeforePacifiedAttack);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
     }
 
@@ -53,16 +53,31 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         }
     }
 
-    private void OnMapInit(Entity<CryoSicknessComponent> ent, ref MapInitEvent args)
+    private void EnsureCryoInitialized(Entity<CryoSicknessComponent> ent)
     {
-        var duration = TimeSpan.FromMinutes(ent.Comp.DurationInMinutes);
-        ent.Comp.ExpireTime = _timing.CurTime + duration;
-        ent.Comp.HadPacifism = HasComp<PacifiedComponent>(ent);
-        if (!_statusEffectsSystem.HasStatusEffect(ent.Owner, ent.Comp.Effect))
-            _statusEffectsSystem.TryAddStatusEffectDuration(ent.Owner, ent.Comp.Effect, duration);
+        if (ent.Comp.ExpireTime == default)
+        {
+            var duration = TimeSpan.FromMinutes(ent.Comp.DurationInMinutes);
+            ent.Comp.ExpireTime = _timing.CurTime + duration;
+            ent.Comp.HadPacifism = HasComp<PacifiedComponent>(ent);
+
+            if (!_statusEffectsSystem.HasStatusEffect(ent.Owner, ent.Comp.Effect))
+                _statusEffectsSystem.TryAddStatusEffect(ent.Owner, ent.Comp.Effect, duration, true, new PacifiedComponent());
+        }
+
         EnsureComp<PacifiedComponent>(ent);
         _actions.AddAction(ent.Owner, ref ent.Comp.ActionEntity, ent.Comp.Action);
         _tagSystem.AddTag(ent, _cryoSicknessTag);
+    }
+
+    private void OnStartup(Entity<CryoSicknessComponent> ent, ref ComponentStartup args)
+    {
+        EnsureCryoInitialized(ent);
+    }
+
+    private void OnMapInit(Entity<CryoSicknessComponent> ent, ref MapInitEvent args)
+    {
+        EnsureCryoInitialized(ent);
     }
 
     private void OnShutdown(Entity<CryoSicknessComponent> ent, ref ComponentShutdown args)
@@ -84,7 +99,7 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 
     private void OnPlayerAttach<T>(Entity<CryoSicknessComponent> ent, ref T args) where T : EntityEventArgs
     {
-        _actions.AddAction(ent.Owner, ref ent.Comp.ActionEntity, ent.Comp.Action);
+        EnsureCryoInitialized(ent);
     }
 
     private void OnDamageChange(Entity<CryoSicknessComponent> ent, ref DamageChangedEvent args)
@@ -127,7 +142,8 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 
     public void ApplyComponent(EntityUid ent)
     {
-        EnsureComp<CryoSicknessComponent>(ent);
+        var comp = EnsureComp<CryoSicknessComponent>(ent);
+        EnsureCryoInitialized((ent, comp));
 
     }
 
@@ -147,15 +163,4 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         RemComp<CryoSicknessComponent>(ent);
     }
 
-    private void OnBeforePacifiedAttack(Entity<CryoSicknessComponent> ent, ref BeforePacifiedAttackEvent args)
-    {
-        if (ent.Comp.HadPacifism) return;
-        if (args.Target is not { } target) return;
-        // Allow entities to attack other entities that have never had cryo sickness (e.g. rats, etc)
-        if (!_tagSystem.HasTag(target, _cryoSicknessTag))
-        {
-            args.Cancel();
-            return;
-        }
-    }
 }


### PR DESCRIPTION
1. Perstronzio in all his genius fucked up with the cryo sickness component and it was erroring out a lot.
2. CombatTrained was absolutely spamming the shit out of the server because it was trying to remove CombatTrained from an already deleted entity at roundend.
3. Lag fixes and disabled pvs by default in ccvar file for roundend performance. If you don't want this fix then just set the ccvar to false in your server start script.