### PR TITLE
Fix slow on damage traits

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -78,7 +78,8 @@ public sealed class TraitSystem : EntitySystem
             // End Goobstation: Species trait support
 
             // Add all components required by the prototype
-            EntityManager.AddComponents(mob, traitPrototype.Components, false);
+            // Ratbite: Remove existing otherwise some components don't work
+            EntityManager.AddComponents(mob, traitPrototype.Components, true);
 
             // Einstein Engines - Language begin (remove this if trait system refactor)
             // Remove/Add Languages required by the prototype

--- a/Content.Shared/Damage/Components/SlowOnDamageComponent.cs
+++ b/Content.Shared/Damage/Components/SlowOnDamageComponent.cs
@@ -12,13 +12,14 @@ namespace Content.Shared.Damage.Components
 {
     // TODO It'd be nice if this could be a destructible threshold, but on the other hand,
     // that doesn't really work with events at all, and
-    [RegisterComponent, NetworkedComponent]
+    [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
     public sealed partial class SlowOnDamageComponent : Component
     {
         /// <summary>
         ///     Damage -> movespeed dictionary. This is -damage-, not -health-.
         /// </summary>
-        [DataField("speedModifierThresholds", required: true)]
-        public Dictionary<FixedPoint2, float> SpeedModifierThresholds = default!;
+        /// Ratbite: Make networked field to make it work with trait system
+        [DataField("speedModifierThresholds", required: true), AutoNetworkedField]
+        public Dictionary<FixedPoint2, float> SpeedModifierThresholds = new();
     }
 }

--- a/Resources/Prototypes/_Mono/Traits/physical.yml
+++ b/Resources/Prototypes/_Mono/Traits/physical.yml
@@ -211,8 +211,8 @@
   components:
     - type: SlowOnDamage
       speedModifierThresholds:
-        "45": 0.70
-        "65": 0.46
+        45: 0.70
+        65: 0.46
 
 - type: trait
   id: TrapAvoider
@@ -302,8 +302,8 @@
   components:
   - type: SlowOnDamage
     speedModifierThresholds:
-      "70": 0.83
-      "90": 0.70
+      70: 0.83
+      90: 0.70
 
 - type: trait
   id: DermalArmor


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fix traits that changed slow on damage not doing anything (Feeble and Steadfast).
When these components were added to an entity that didn't have the SlowOnDamageComponent, the client and server would desync, causing the client to have a null reference and throw hundreds of errors potentially causing lag. I reproduced this by forcing a borg to have the component, however borgs were already blacklisted and I am not aware of any other entity that doesn't have that lacks the component naturally. However, the fix to make these traits work should also fix the error spam

## Why / Balance
Bug fix

## Technical details
Traits now replace components when they are already added

## Media
<img width="640" height="159" alt="image" src="https://github.com/user-attachments/assets/6c76be7a-e267-4020-8548-80c0e6382fa9" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Feeble and steadfast not doing anything
