### PR TITLE
Partially revert cryo sickness system changes and remove status effect instead

### DIFF
--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
@@ -1,6 +1,5 @@
 using Content.Goobstation.Maths.FixedPoint;
 using Content.Shared.Actions;
-using Content.Shared.StatusEffect;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -17,9 +16,6 @@ public sealed partial class CryoSicknessComponent : Component
 
     [DataField]
     public EntProtoId Action = "ActionShakeAwake";
-
-    [DataField]
-    public ProtoId<StatusEffectPrototype> Effect = "Pacified";
 
     [DataField]
     public float DamageResistance = 0.6f;

--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
@@ -4,10 +4,8 @@ using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
-using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
 using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -19,7 +17,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
 
@@ -27,18 +24,18 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
     // Entities with this tag cannot be attacked by people who are
     // pacified by cryosickness.
     private readonly ProtoId<TagPrototype> _cryoSicknessTag = "CryoSickness";
-    [Dependency] private readonly ISharedAdminLogManager _adminLog = default!; // Ratbite: add logs when drawing implants
+    [Dependency] private readonly ISharedAdminLogManager _adminLog = default!;
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<CryoSicknessComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<CryoSicknessComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<CryoSicknessComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<CryoSicknessComponent, DamageModifyEvent>(OnDamageModifyEvent);
         SubscribeLocalEvent<CryoSicknessComponent, DamageChangedEvent>(OnDamageChange);
         SubscribeLocalEvent<CryoSicknessComponent, MindAddedMessage>(OnPlayerAttach);
         SubscribeLocalEvent<CryoSicknessComponent, PlayerAttachedEvent>(OnPlayerAttach);
         SubscribeLocalEvent<CryoSicknessComponent, ShakeAwakeEvent>(OnShakeAwake);
+        SubscribeLocalEvent<CryoSicknessComponent, BeforePacifiedAttackEvent>(OnBeforePacifiedAttack);
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawn);
     }
 
@@ -53,31 +50,14 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         }
     }
 
-    private void EnsureCryoInitialized(Entity<CryoSicknessComponent> ent)
+    private void OnMapInit(Entity<CryoSicknessComponent> ent, ref MapInitEvent args)
     {
-        if (ent.Comp.ExpireTime == default)
-        {
-            var duration = TimeSpan.FromMinutes(ent.Comp.DurationInMinutes);
-            ent.Comp.ExpireTime = _timing.CurTime + duration;
-            ent.Comp.HadPacifism = HasComp<PacifiedComponent>(ent);
-
-            if (!_statusEffectsSystem.HasStatusEffect(ent.Owner, ent.Comp.Effect))
-                _statusEffectsSystem.TryAddStatusEffect(ent.Owner, ent.Comp.Effect, duration, true, new PacifiedComponent());
-        }
-
+        var duration = TimeSpan.FromMinutes(ent.Comp.DurationInMinutes);
+        ent.Comp.ExpireTime = _timing.CurTime + duration;
+        ent.Comp.HadPacifism = HasComp<PacifiedComponent>(ent);
         EnsureComp<PacifiedComponent>(ent);
         _actions.AddAction(ent.Owner, ref ent.Comp.ActionEntity, ent.Comp.Action);
         _tagSystem.AddTag(ent, _cryoSicknessTag);
-    }
-
-    private void OnStartup(Entity<CryoSicknessComponent> ent, ref ComponentStartup args)
-    {
-        EnsureCryoInitialized(ent);
-    }
-
-    private void OnMapInit(Entity<CryoSicknessComponent> ent, ref MapInitEvent args)
-    {
-        EnsureCryoInitialized(ent);
     }
 
     private void OnShutdown(Entity<CryoSicknessComponent> ent, ref ComponentShutdown args)
@@ -85,7 +65,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         if (LifeStage(ent) >= EntityLifeStage.Terminating) return;
         if (!ent.Comp.HadPacifism)
         {
-            _statusEffectsSystem.TryRemoveStatusEffect(ent.Owner, ent.Comp.Effect);
             RemComp<PacifiedComponent>(ent);
         }
         _popup.PopupClient(Loc.GetString("cryosickness-end-popup"), ent.Owner, ent.Owner);
@@ -99,7 +78,7 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 
     private void OnPlayerAttach<T>(Entity<CryoSicknessComponent> ent, ref T args) where T : EntityEventArgs
     {
-        EnsureCryoInitialized(ent);
+        _actions.AddAction(ent.Owner, ref ent.Comp.ActionEntity, ent.Comp.Action);
     }
 
     private void OnDamageChange(Entity<CryoSicknessComponent> ent, ref DamageChangedEvent args)
@@ -113,7 +92,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         if ((args.DamageDelta?.GetTotal() ?? 0) < ent.Comp.MinDamageBeforeRemove && args.Damageable.Damage.GetTotal() < ent.Comp.MinTotalDamageBeforeRemove) return;
         if (!ent.Comp.HadPacifism)
         {
-            _statusEffectsSystem.TryRemoveStatusEffect(ent.Owner, ent.Comp.Effect);
             if (RemComp<PacifiedComponent>(ent))
             {
                 // I'm not completely sold if it should be removed
@@ -142,8 +120,7 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 
     public void ApplyComponent(EntityUid ent)
     {
-        var comp = EnsureComp<CryoSicknessComponent>(ent);
-        EnsureCryoInitialized((ent, comp));
+        EnsureComp<CryoSicknessComponent>(ent);
 
     }
 
@@ -163,4 +140,15 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         RemComp<CryoSicknessComponent>(ent);
     }
 
+    private void OnBeforePacifiedAttack(Entity<CryoSicknessComponent> ent, ref BeforePacifiedAttackEvent args)
+    {
+        if (ent.Comp.HadPacifism) return;
+        if (args.Target is not { } target) return;
+        // Allow entities to attack other entities that have never had cryo sickness (e.g. rats, etc)
+        if (!_tagSystem.HasTag(target, _cryoSicknessTag))
+        {
+            args.Cancel();
+            return;
+        }
+    }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR

## Why / Balance

The system was working fine, the only problem was the status effect not applying because the effect didn't exist, but it has been removed because it's not needed (And isn't working anyways in both #496 and before it), #496 removes the fact that people can attack entities that never had cryo sick, which forces people to shake themselves awake in case of something like a mouse attacking people

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

