### PR TITLE
Contraband tweaks

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -106,12 +106,23 @@ namespace Content.Shared.Localizations
         }
 
         private static readonly Regex PluralEsRule = new("^.*(s|sh|ch|x|z)$");
+        // Ratbite: fix grammar for things like Head of Security -> Heads of Security
+        private static readonly Regex HeadOfRule = new("^Head of (.*)$");
 
         private ILocValue FormatMakePlural(LocArgs args)
         {
             var text = ((LocValueString) args.Args[0]).Value;
+
             var split = text.Split(" ", 1);
             var firstWord = split[0];
+
+            // Ratbite start
+            var match = HeadOfRule.Match(firstWord);
+            if (match.Success)
+            {
+                return new LocValueString($"Heads of {match.Groups[1]}");
+            }
+            // Ratbite end
             if (PluralEsRule.IsMatch(firstWord))
             {
                 if (split.Length == 1)

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -106,23 +106,14 @@ namespace Content.Shared.Localizations
         }
 
         private static readonly Regex PluralEsRule = new("^.*(s|sh|ch|x|z)$");
-        // Ratbite: fix grammar for things like Head of Security -> Heads of Security
-        private static readonly Regex HeadOfRule = new("^Head of (.*)$");
 
         private ILocValue FormatMakePlural(LocArgs args)
         {
             var text = ((LocValueString) args.Args[0]).Value;
-
-            var split = text.Split(" ", 1);
+            // Ratbite: Changed 1 to 2 because it looks like a typo
+            // when looking at the code that's after
+            var split = text.Split(" ", 2);
             var firstWord = split[0];
-
-            // Ratbite start
-            var match = HeadOfRule.Match(firstWord);
-            if (match.Success)
-            {
-                return new LocValueString($"Heads of {match.Groups[1]}");
-            }
-            // Ratbite end
             if (PluralEsRule.IsMatch(firstWord))
             {
                 if (split.Length == 1)

--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -110,9 +110,7 @@ namespace Content.Shared.Localizations
         private ILocValue FormatMakePlural(LocArgs args)
         {
             var text = ((LocValueString) args.Args[0]).Value;
-            // Ratbite: Changed 1 to 2 because it looks like a typo
-            // when looking at the code that's after
-            var split = text.Split(" ", 2);
+            var split = text.Split(" ", 1);
             var firstWord = split[0];
             if (PluralEsRule.IsMatch(firstWord))
             {

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -186,7 +186,7 @@
         Blunt: 10
 
 - type: entity
-  parent: ClothingEyesBase # goobstation - tider nation - no longer contra
+  parent: [ClothingEyesBase, BaseEngineeringContraband] # goobstation - tider nation - no longer contra # Ratbite: Make contraband again
   id: ClothingEyesGlassesMeson
   name: meson goggles # goobstation - they're called MESONS!!!!
   description: Green-tinted goggles using a proprietary polymer that provides protection from eye damage of all types.

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -186,7 +186,7 @@
         Blunt: 10
 
 - type: entity
-  parent: [ClothingEyesBase, BaseEngineeringContraband] # goobstation - tider nation - no longer contra # Ratbite: Make contraband again
+  parent: ClothingEyesBase # goobstation - tider nation - no longer contra
   id: ClothingEyesGlassesMeson
   name: meson goggles # goobstation - they're called MESONS!!!!
   description: Green-tinted goggles using a proprietary polymer that provides protection from eye damage of all types.
@@ -203,6 +203,9 @@
     tags:
     - PetWearable
     - WhitelistChameleon
+  - type: Contraband # Ratbite: Made contraband again
+    allowedDepartments: [ Engineering, Cargo ]
+    allowedJobs: [ BlueshieldOfficer ]
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -266,6 +266,7 @@
   parent:
   - BaseItem
   - AiHolder
+  - BaseScienceContraband # Ratbite: contraband changes
   suffix: Empty
   components:
   - type: ContainerComp

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -85,7 +85,7 @@
         swap: false
 
 - type: entity
-  parent: BaseItem # DeltaV - remove powercell requirement
+  parent: [BaseItem, BaseEngineeringContraband] # DeltaV - remove powercell requirement # Ratbite: contraband changes
   id: HolofanProjector
   name: holofan projector
   description: Stop suicidal passengers from killing everyone during atmos emergencies.

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -85,7 +85,7 @@
         swap: false
 
 - type: entity
-  parent: [BaseItem, BaseEngineeringContraband] # DeltaV - remove powercell requirement # Ratbite: contraband changes
+  parent: [BaseItem, BaseScienceEngContraband] # DeltaV - remove powercell requirement # Ratbite: contraband changes
   id: HolofanProjector
   name: holofan projector
   description: Stop suicidal passengers from killing everyone during atmos emergencies.

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -639,7 +639,7 @@
     count: 1
 
 - type: entity
-  parent: MaterialBase
+  parent: [MaterialBase, BaseMajorContraband] # Ratbite: contraband changes
   id: MaterialBananium
   name: bananium
   suffix: Full

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -53,7 +53,7 @@
 # Base
 
 - type: entity
-  parent: [BaseItem, BaseMedicalContraband] # Ratbite: contraband changes
+  parent: [BaseItem, BaseMedicalScienceContraband] # Ratbite: contraband changes
   id: BaseToolSurgery
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -53,7 +53,7 @@
 # Base
 
 - type: entity
-  parent: BaseItem
+  parent: [BaseItem, BaseMedicalContraband] # Ratbite: contraband changes
   id: BaseToolSurgery
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
@@ -7,7 +7,7 @@
 
 - type: entity
   id: BaseXenoArtifact
-  parent: BaseMob # we use this since it can technically get inhabited
+  parent: [BaseMob, BaseScienceContraband] # we use this since it can technically get inhabited # Ratbite: contraband changes
   name: artifact
   description: A strange artifact from time unknown. Looks like a good time.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -137,7 +137,7 @@
       Plasma: 75
       Gold: 12
   - type: Contraband # Ratbite: contraband changes
-    allowedDepartments: [ Engineering, Cargo ]
+    allowedDepartments: [ Engineering, Cargo, Science ]
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jaws_of_life.yml
@@ -136,6 +136,8 @@
       Glass: 125
       Plasma: 75
       Gold: 12
+  - type: Contraband # Ratbite: contraband changes
+    allowedDepartments: [ Engineering, Cargo ]
 
 - type: entity
   name: syndicate jaws of life

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -344,7 +344,7 @@
 
 - type: entity
   name: multitool
-  parent: [BaseItem, BaseSecurityEngineeringContraband] ] # Ratbite: contraband changes. Warden spawns with a multitool, so needs to be security too
+  parent: [BaseItem, BaseSecurityEngineeringContraband] # Ratbite: contraband changes. Warden spawns with a multitool, so needs to be security too
   id: Multitool
   description: An advanced tool to copy, store, and send electrical pulses and signals through wires and machines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -344,7 +344,7 @@
 
 - type: entity
   name: multitool
-  parent: BaseItem
+  parent: [BaseItem, BaseSecurityEngineeringContraband] ] # Ratbite: contraband changes. Warden spawns with a multitool, so needs to be security too
   id: Multitool
   description: An advanced tool to copy, store, and send electrical pulses and signals through wires and machines.
   components:

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -344,7 +344,7 @@
 
 - type: entity
   name: multitool
-  parent: [BaseItem, BaseSecurityEngineeringContraband] # Ratbite: contraband changes. Warden spawns with a multitool, so needs to be security too
+  parent: BaseItem
   id: Multitool
   description: An advanced tool to copy, store, and send electrical pulses and signals through wires and machines.
   components:
@@ -404,6 +404,9 @@
     - WirePanels
     - Airlocks
     - InspectingPower
+  - type: Contraband  # Ratbite: contraband changes. Command and warden spawn with one, science need it for artifacts
+    allowedDepartments: [ Engineering, Command, Science ]
+    allowedJobs: [ Warden ]
 
 - type: entity
   name: network configurator

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -211,6 +211,8 @@
     damage:
       types:
         Slash: 10
+  - type: Contraband # Ratbite contraband tweaks
+    allowedJobs: [ Chef, ServiceWorker ]
 
 - type: entity
   name: butcher's cleaver
@@ -242,6 +244,8 @@
     speed: 0.3
   - type: BoneSaw # Shitmed: Better than tg 25% because its a cleaver its meant to hack off limbs
     speed: 0.5
+  - type: Contraband # Ratbite, service workers shouldn't use cleavers, only chefs
+    allowedJobs: [ Chef ]
 
 - type: entity
   name: combat knife

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -187,6 +187,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Cargo ]
+    allowedJobs: [ BlueshieldOfficer ] # Ratbite
 
 - type: entity
   id: BaseMedicalScienceContraband

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -191,7 +191,7 @@
       group: Canisters
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: StorageCanister
   name: storage canister
   components:
@@ -449,7 +449,7 @@
     access: [["Atmospherics"]]
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: PlasmaCanister
   name: plasma canister
   description: A canister that can contain any type of gas. This one is supposed to contain plasma. It can be attached to connector ports using a wrench.
@@ -493,7 +493,7 @@
       locked: true
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: TritiumCanister
   name: tritium canister
   description: A canister that can contain any type of gas. This one is supposed to contain tritium. It can be attached to connector ports using a wrench.
@@ -582,7 +582,7 @@
         - !type:DumpCanisterBehavior
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: AmmoniaCanister
   name: ammonia canister
   description: A canister that can contain any type of gas. This one is supposed to contain ammonia. It can be attached to connector ports using a wrench.
@@ -629,7 +629,7 @@
       locked: true
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: NitrousOxideCanister
   name: nitrous oxide canister
   description: A canister that can contain any type of gas. This one is supposed to contain nitrous oxide. It can be attached to connector ports using a wrench.
@@ -677,7 +677,7 @@
       locked: true
 
 - type: entity
-  parent: GasCanister
+  parent: [GasCanister, BaseScienceEngContraband] # Ratbite: contraband changes
   id: FrezonCanister
   name: frezon canister
   description: A canister that can contain any type of gas. This one is supposed to contain frezon. It can be attached to connector ports using a wrench.

--- a/Resources/Prototypes/_BRatbite/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Objects/base_contraband.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: BaseScienceEngContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Engineering, Science ]

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Belt/belts.yml
@@ -212,6 +212,8 @@
           tags:
           - Justice
   - type: Appearance
+  - type: Contraband # Ratbite: contraband changes
+    allowedJobs: [ Warden, HeadOfSecurity ]
 
 - type: entity
   parent: [ ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseSyndicateContraband ]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -126,7 +126,7 @@
 
 - type: entity
   id: EnergyChemDispenserMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [BaseMachineCircuitboard, BaseMedicalScienceContraband] # Ratbite: contraband changes
   name: energy chem dispenser machine board
   description: A machine printed circuit board for an energy chem dispenser.
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Devices/door_remote.yml
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity 
-  parent: DoorRemoteDefault
+  parent: [DoorRemoteDefault, BaseEngineeringContraband] # Ratbite: contraband changes
   id: DoorRemoteFirefight
   name: fire-fighting door remote
   description: A gadget which can open and bolt FireDoors remotely.

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/portable_chem_master.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Specific/Medical/portable_chem_master.yml
@@ -50,7 +50,7 @@
 
 - type: entity
   id: portableChemicalMixer
-  parent: BaseItem
+  parent: [BaseItem, BaseMedicalContraband] # Ratbite: contraband changes
   name: portable chemical mixer
   description: A "Tider" grade chemical manipulator
   components:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/justice.yml
@@ -11,7 +11,7 @@
 
 - type: entity
   name: DT-2
-  parent: [BaseItem,]
+  parent: BaseItem
   id: Justice
   description: An expensive & self-recharging energy sword, designed for high ranking members of security. It deals more damage to unruly prisoners.
   components:
@@ -75,6 +75,9 @@
   - type: HosSaber
     # This is a 3% multiplicative buff per every hour of sentence.
     damageMultiplierPerMinute: 0.0005
+    # Ratbite: Contraband
+  - type: Contraband
+    allowedJobs: [Warden, HeadOfSecurity]
   - type: ItemSwitch
     needsPower: true
     defaultState: off

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/kravmagagloves.yml
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 - type: entity
-  parent: [ ClothingHandsBase , BaseWardenContraband ]
+  parent: ClothingHandsBase
   id: ClothingHandsGlovesKravMaga
   name: Krav Maga gloves
   description: These gloves can teach you to perform Krav Maga using nanochips for as long as you're wearing them.
@@ -30,3 +30,5 @@
   - type: GuideHelp
     guides:
     - KravMaga
+  - type: Contraband # Ratbite: contraband changes
+    allowedJobs: [ Warden, HeadOfSecurity ]

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/base_contraband.yml
@@ -29,6 +29,7 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Engineering, Cargo ]
+    allowedJobs: [ BlueshieldOfficer ] # Ratbite
 
 - type: entity
   id: BaseSecurityZookeeperContraband # Tranq shells

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/dispensers.yml
@@ -6,7 +6,7 @@
 
 - type: entity
   id: EnergyChemDispenser
-  parent: SmallConstructibleMachine
+  parent: [SmallConstructibleMachine, BaseMedicalScienceContraband] # Ratbite: contraband changes
   name: energy chemical dispenser
   suffix: energy
   description: A bluespace Chemical Dispenser that uses station energy to synthesize Reagents. The future is here and now.

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Materials/ore.yml
@@ -202,7 +202,7 @@
     count: 1
 
 - type: entity
-  parent: BananiumOre
+  parent: [BananiumOre, BaseMajorContraband] # Ratbite: contraband changes
   id: BananiumOreUnprocessed
   name: unprocessed bananium ore
   suffix: Full

--- a/Resources/Prototypes/_Shitmed/Entities/Specific/Abductor/surgery.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Specific/Abductor/surgery.yml
@@ -62,6 +62,8 @@
     interfaces:
       enum.MagicMirrorUiKey.Key:
         type: MagicMirrorBoundUserInterface
+  - type: Contraband # Ratbite: manual component because basesurgerytools derives from medical contraband
+    severity: Major
 
 - type: entity
   name: high-tech searing tool
@@ -97,6 +99,8 @@
   - type: GuideHelp
     guides:
     - Abductors
+  - type: Contraband # Ratbite: manual component because basesurgerytools derives from medical contraband
+    severity: Major
 
 - type: entity
   name: high-tech energy scalpel
@@ -134,6 +138,8 @@
   - type: GuideHelp
     guides:
     - Abductors
+  - type: Contraband # Ratbite: manual component because basesurgerytools derives from medical contraband
+    severity: Major
 
 - type: entity
   name: high-tech bone manipulator
@@ -162,3 +168,5 @@
     - type: GuideHelp
       guides:
       - Abductors
+    - type: Contraband # Ratbite: manual component because basesurgerytools derives from medical contraband
+      severity: Major


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR

Contraband tweaks. ~~Also fix bug where Head of Security would be pluralized as Head of Securitys instead of Heads of Security~~ (Reverted because it breaks other things, I will probably open another PR)

## Why / Balance
The affected items are:
- All CargoSec contraband are now usable by BSO (e.g. combat gloves, jackboots, etc)
- Meson glasses (eng, cargo for salvage, BSO)
- Intellicard (sci only)
- Holofan (eng, sci)
- Bananium, material and ore (major contraband)
- All surgery tools (Except syndicate ones) (Medical and science only)
- Artifacts (Science only)
- Jaws of life (Engineering, cargo for salvage, science because they can print it)
- Multitool (Engineering, Command for flatpacks, Science for artifacts, Warden)
- Knife (Service worker, chef)
- Butcher cleaver (Chef)
- Dangerous canisters [so excluding oxygen, nitrogen, etc] (Eng, science for artifacts)
- Former hos sheath, krav maga gloves (Now they are HoS/Warden)
- Energy Chem Boards and machines (Medical and science for artifact glue)
- Fire fighting remote (Engineering)
- Portable chemical mixer (Med only)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Contraband changes
