### PR TITLE
Add security time requirement to sec reinforcement of 5 hours

### DIFF
--- a/Content.Server/_Trauma/Ghost/DelayedGhostRoleSystem.cs
+++ b/Content.Server/_Trauma/Ghost/DelayedGhostRoleSystem.cs
@@ -86,6 +86,7 @@ public sealed class DelayedGhostRoleSystem : EntitySystem
         role.RoleRules = comp.Rules;
         role.MindRoles = comp.MindRoles;
         role.JobProto = comp.Job;
+        role.Requirements = comp.Requirements;
         RemComp(uid, comp);
     }
 }

--- a/Content.Shared/_Trauma/Ghost/DelayedGhostRoleComponent.cs
+++ b/Content.Shared/_Trauma/Ghost/DelayedGhostRoleComponent.cs
@@ -44,4 +44,8 @@ public sealed partial class DelayedGhostRoleComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<JobPrototype>? Job;
+
+    // Ratbite Add job requirements to delayed ghost roles as well
+    [DataField]
+    public HashSet<JobRequirement>? Requirements;
 }

--- a/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/reinforcement_beacons.yml
+++ b/Resources/Prototypes/_Trauma/Entities/Objects/Devices/Reinforcements/reinforcement_beacons.yml
@@ -63,6 +63,10 @@
   - type: DelayedGhostRole
     job: SecurityOfficer
     name: ghost-role-information-reinforcement-sec-name
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Security
+      time: 18000 # five hours
   - type: GhostCharacterSpawner
     components:
     - type: Loadout


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add 5 hours of sec playtime requirement before being able to pick sec reinforcement

## Why / Balance
Raiders would pick sec reinforcement and try to arrest everyone

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="548" height="284" alt="image" src="https://github.com/user-attachments/assets/e8ce4ae1-ad01-432b-a43d-57eb90fbb886" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Sec reinforcement requires 5 hours of playtime
