### PR TITLE
Nudist trait

### DIFF
--- a/Content.Shared/_BRatbite/Traits/NudistComponent.cs
+++ b/Content.Shared/_BRatbite/Traits/NudistComponent.cs
@@ -1,0 +1,34 @@
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.Traits;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class NudistComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<SlotFlags, ClothingModifier> ClothingModifier = new();
+
+    [DataField, AutoNetworkedField]
+    public ClothingModifier BaseModifier = new(1.2f, 1.15f);
+
+    [DataField, AutoNetworkedField]
+    public ClothingModifier CachedModifier = new(1f, 1f);
+}
+
+
+[Serializable, DataDefinition]
+public partial struct ClothingModifier
+{
+    [DataField]
+    public float SpeedModifier;
+
+    [DataField]
+    public float StaminaModifier;
+
+    public ClothingModifier(float speedModifier, float staminaModifier)
+    {
+        SpeedModifier = speedModifier;
+        StaminaModifier = staminaModifier;
+    }
+}

--- a/Content.Shared/_BRatbite/Traits/NudistSystem.cs
+++ b/Content.Shared/_BRatbite/Traits/NudistSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Systems;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared._BRatbite.Traits;
+
+public sealed partial class NudistSystem : EntitySystem
+{
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SharedStaminaSystem _staminaSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<NudistComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeed);
+        SubscribeLocalEvent<NudistComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<NudistComponent, DidEquipEvent>(OnRecomputeNeeded);
+        SubscribeLocalEvent<NudistComponent, DidUnequipEvent>(OnRecomputeNeeded);
+    }
+
+    private void OnRefreshMovementSpeed(Entity<NudistComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        args.ModifySpeed(ent.Comp.CachedModifier.SpeedModifier);
+    }
+
+    private void RecomputeModifiers(Entity<NudistComponent> ent)
+    {
+        ent.Comp.CachedModifier = ent.Comp.BaseModifier;
+        foreach (var (flags, modifier) in ent.Comp.ClothingModifier)
+        {
+            if (!_inventorySystem.TryGetContainerSlotEnumerator(ent.Owner, out var containerSlotEnum, flags)) continue;
+            if (!containerSlotEnum.NextItem(out _)) continue;
+            ent.Comp.CachedModifier.SpeedModifier *= modifier.SpeedModifier;
+            ent.Comp.CachedModifier.StaminaModifier *= modifier.StaminaModifier;
+        }
+        Dirty(ent, ent.Comp);
+        var stamMod = EnsureComp<StaminaModifierComponent>(ent);
+        _staminaSystem.SetModifier(ent.Owner, ent.Comp.CachedModifier.StaminaModifier, null, stamMod);
+    }
+
+    private void OnMapInit(Entity<NudistComponent> ent, ref MapInitEvent args)
+    {
+        if (TryComp<StaminaModifierComponent>(ent, out var staminaModifierComp))
+            ent.Comp.BaseModifier.StaminaModifier *= staminaModifierComp.Modifier;
+        RecomputeModifiers(ent);
+    }
+
+    private void OnRecomputeNeeded<T>(Entity<NudistComponent> ent, ref T _)
+    {
+        RecomputeModifiers(ent);
+    }
+}

--- a/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
+++ b/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
@@ -76,5 +76,5 @@ gun-fail-shoot = Your hands tremble and you were unable to shoot.
 trait-stowaway-name = Stowaway
 trait-stowaway-desc = You weren't mean to be on this ship, but you are here anyways and have to survive.
 
-trait-nude-name = Nudist
-trait-nude-description = You have a hatred for clothing, and are faster when not wearing anything
+trait-nude-name = Vestiphobia
+trait-nude-description = You have an irrational fear of clothing, and are slower when wearing them

--- a/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
+++ b/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
@@ -75,3 +75,6 @@ gun-fail-shoot = Your hands tremble and you were unable to shoot.
 
 trait-stowaway-name = Stowaway
 trait-stowaway-desc = You weren't mean to be on this ship, but you are here anyways and have to survive.
+
+trait-nude-name = Nudist
+trait-nude-description = You have a hatred for clothing, and are faster when not wearing anything

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -134,13 +134,15 @@
   # Einstein Engines - Language end
 
   # Ratbite
-  - CaptainSaberWeaknessComponent
+  - CaptainSaberWeakness
   - Prisoner
   - Atheist
   - CombatTrained
   - CombatUntrained
-  - Mindshield # Prevent people from acting violent after cloning
-  - FakeMindshield # Just to prevent metagaming
+  - MindShield # Prevent people from acting violent after cloning
+  - FakeMindShield # Just to prevent metagaming
+  - ScaredOfGuns
+  - Nudist
   # End ratbite
 
   blacklist:

--- a/Resources/Prototypes/_BRatbite/Traits/traits.yml
+++ b/Resources/Prototypes/_BRatbite/Traits/traits.yml
@@ -242,3 +242,31 @@
   cost: -1
   components:
   - type: Stowaway
+
+- type: trait
+  id: Nudist
+  name: trait-nude-name
+  description: trait-nude-description
+  category: Mental
+  cost: 5
+  components:
+  - type: Nudist
+    baseModifier:
+      speedModifier: 1.2
+      staminaModifier: 1.15
+    clothingModifier:
+      FEET:
+        speedModifier: .95
+        staminaModifier: .95
+      GLOVES:
+        speedModifier: .95
+        staminaModifier: .95
+      HEAD:
+        speedModifier: .95
+        staminaModifier: .95
+      INNERCLOTHING:
+        speedModifier: .80
+        staminaModifier: .85
+      OUTERCLOTHING:
+        speedModifier: .85
+        staminaModifier: .90


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add Nudist trait.
Nudists have a buff to movement speed of 20% and stamina to 15%, however if they wear certain items of clothing (Shoes, gloves, hats, jumpsuits, armor) they receive a speed and stamina debuff (See yaml for the exact numbers).
Also fix some typos on cloning traits

## Why  / Balance
Glass cannons since they are slow if they wear armor

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="763" height="79" alt="image" src="https://github.com/user-attachments/assets/fd97acbf-3822-4cb7-a58f-35a9882e9215" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Nudist trait
