### PR TITLE
Make plural fix

### DIFF
--- a/Content.Shared/Localizations/ContentLocalizationManager.cs
+++ b/Content.Shared/Localizations/ContentLocalizationManager.cs
@@ -106,27 +106,27 @@ namespace Content.Shared.Localizations
         }
 
         private static readonly Regex PluralEsRule = new("^.*(s|sh|ch|x|z)$");
+        private static readonly Regex PluralOfRule = new("(.*) of (.*)");
 
+        // Ratbite: Plural fix
         private ILocValue FormatMakePlural(LocArgs args)
         {
             var text = ((LocValueString) args.Args[0]).Value;
-            var split = text.Split(" ", 1);
-            var firstWord = split[0];
-            if (PluralEsRule.IsMatch(firstWord))
+            var match = PluralOfRule.Match(text);
+            if (match.Success)
             {
-                if (split.Length == 1)
-                    return new LocValueString($"{firstWord}es");
-                else
-                    return new LocValueString($"{firstWord}es {split[1]}");
+                // E.g. Head of Security -> Heads of Security
+                return new LocValueString($"{PluralizeWord(match.Groups[1].Value)} of {match.Groups[2].Value}");
             }
-            else
-            {
-                if (split.Length == 1)
-                    return new LocValueString($"{firstWord}s");
-                else
-                    return new LocValueString($"{firstWord}s {split[1]}");
-            }
+            // e.g. Blueshield Officer -> Blueshield Officers
+            return new LocValueString(PluralizeWord(text));
         }
+
+        private string PluralizeWord(string word)
+        {
+            return PluralEsRule.IsMatch(word) ? $"{word}es" : $"{word}s";
+        }
+        // Ratbite end
 
         // TODO: allow fluent to take in lists of strings so this can be a format function like it should be.
         /// <summary>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
MAKEPLURAL produced weird results for strings like `Head of Security`, being pluralized as `Head of Securitys`.
The old code is trying to Pluralize the first word of the string (`return new LocValueString($"{firstWord}s {split[1]}");`), however they are also splitting the string with `text.Split(" ", 1);`, which always returns a list with the entire string in it and never actually splits in firstWord and rest as the author inteded, and just adds an S at the end.
Some localization do depend on this behavior, for example "Blueshield Officer" should get pluralized as "Blueshield Officers" and not "Blueshieds officer", so I made it so strings matching `(.*) of (.*)` will get pluralized by adding an S to the first word, while other strings will keep the current unintended behavior.

## Why / Balance
Bug fix

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="934" height="213" alt="image" src="https://github.com/user-attachments/assets/6603ecad-403d-4ac3-8b02-87b5c26e2a82" />
<img width="742" height="144" alt="image" src="https://github.com/user-attachments/assets/dbb122ef-d8b9-4c54-9da4-2c08b44e8648" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fix plurals
