### PR TITLE
Slasher rebalance

### DIFF
--- a/Content.Goobstation.Server/Slasher/Systems/SlasherPossessionSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherPossessionSystem.cs
@@ -25,7 +25,8 @@ public sealed class SlasherPossessionSystem : EntitySystem
 
     private void OnMapInit(Entity<SlasherPossessionComponent> ent, ref MapInitEvent args)
     {
-        _actions.AddAction(ent.Owner, ref ent.Comp.ActionEnt, ent.Comp.ActionId);
+        // Ratbite - Removed possession in favor of regeneration being able to store souls
+        //    _actions.AddAction(ent.Owner, ref ent.Comp.ActionEnt, ent.Comp.ActionId);
     }
 
     private void OnShutdown(Entity<SlasherPossessionComponent> ent, ref ComponentShutdown args)

--- a/Content.Goobstation.Server/Slasher/Systems/SlasherPossessionSystem.cs
+++ b/Content.Goobstation.Server/Slasher/Systems/SlasherPossessionSystem.cs
@@ -26,6 +26,7 @@ public sealed class SlasherPossessionSystem : EntitySystem
     private void OnMapInit(Entity<SlasherPossessionComponent> ent, ref MapInitEvent args)
     {
         // Ratbite - Removed possession in favor of regeneration being able to store souls
+        // Ratbite - Leaving the rest of the code uncommented (since it doesnt really get called anyway.. shouldnt be that much of a problem..?)
         //    _actions.AddAction(ent.Owner, ref ent.Comp.ActionEnt, ent.Comp.ActionId);
     }
 

--- a/Content.Goobstation.Shared/Slasher/Components/SlasherBloodTrailComponent.cs
+++ b/Content.Goobstation.Shared/Slasher/Components/SlasherBloodTrailComponent.cs
@@ -49,4 +49,13 @@ public sealed partial class SlasherBloodTrailComponent : Component
 
     [ViewVariables]
     public EntityUid? FunkyslasherStream;
+
+    // <Ratbite> - made Blood Trail not pure larp/"aura"
+
+    /// <summary>
+    /// The amount of movement speed bonus the slasher gets when using blood trail
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BloodTrailMovementBonus = 1.15f;
+    // </Ratbite>
 }

--- a/Content.Goobstation.Shared/Slasher/Components/SlasherPossessionComponent.cs
+++ b/Content.Goobstation.Shared/Slasher/Components/SlasherPossessionComponent.cs
@@ -14,6 +14,7 @@ public sealed partial class SlasherPossessionComponent : Component
     public EntityUid? ActionEnt;
 
     // Ratbite - Removed possession in favor of regeneration being able to store souls
+    // Ratbite - Leaving the rest of the code uncommented (since it doesnt really get called anyway.. shouldnt be that much of a problem..?)
     // [DataField]
     // public EntProtoId ActionId = "ActionSlasherPossession"; 
 

--- a/Content.Goobstation.Shared/Slasher/Components/SlasherPossessionComponent.cs
+++ b/Content.Goobstation.Shared/Slasher/Components/SlasherPossessionComponent.cs
@@ -13,8 +13,9 @@ public sealed partial class SlasherPossessionComponent : Component
     [ViewVariables]
     public EntityUid? ActionEnt;
 
-    [DataField]
-    public EntProtoId ActionId = "ActionSlasherPossession";
+    // Ratbite - Removed possession in favor of regeneration being able to store souls
+    // [DataField]
+    // public EntProtoId ActionId = "ActionSlasherPossession"; 
 
     /// <summary>
     /// How long you want the possesion to last

--- a/Content.Goobstation.Shared/Slasher/Components/SlasherRegenerateComponent.cs
+++ b/Content.Goobstation.Shared/Slasher/Components/SlasherRegenerateComponent.cs
@@ -32,10 +32,11 @@ public sealed partial class SlasherRegenerateComponent : Component
     /// <summary>
     /// Whether the slasher has a stolen soul available to use for regenerate.
     /// Acts as ammo for the regenerate ability.
-    /// Max of one soul at a time to prevent stacking.
+    /// Ratbite - Made integer instead to allow for having multiple souls stored
+    /// Ratbite - Max of three souls at a time (see SlasherRegenerateSystem.cs)
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool HasSoulAvailable = true; // Start with one soul available
+    public int SoulsAvailable = 1; // Start with one soul available
 
     /// <summary>
     /// The sound that plays when regenerating

--- a/Content.Goobstation.Shared/Slasher/Components/SlasherRegenerateComponent.cs
+++ b/Content.Goobstation.Shared/Slasher/Components/SlasherRegenerateComponent.cs
@@ -29,14 +29,22 @@ public sealed partial class SlasherRegenerateComponent : Component
     [DataField("reagentAmount")]
     public float ReagentAmount = 10f;
 
+    // <Ratbite> - Regenerate can now store more souls
+
     /// <summary>
-    /// Whether the slasher has a stolen soul available to use for regenerate.
+    /// How many souls the slasher has for the Regenerate ability
     /// Acts as ammo for the regenerate ability.
-    /// Ratbite - Made integer instead to allow for having multiple souls stored
-    /// Ratbite - Max of three souls at a time (see SlasherRegenerateSystem.cs)
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int SoulsAvailable = 1; // Start with one soul available
+    public int SoulsAvailable = 1; // Start with one soul available   Ratbite - Now integer, see summary above
+
+    /// <summary>
+    /// The max amount of souls that Regenerate can store
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public int MaxSouls = 3; // Max 3 souls can be stored
+
+    // </Ratbite>
 
     /// <summary>
     /// The sound that plays when regenerating

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherBloodTrailSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherBloodTrailSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Fluids;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Content.Shared.Movement.Systems; // Ratbite
 
 namespace Content.Goobstation.Shared.Slasher.Systems;
 
@@ -20,6 +21,7 @@ public sealed class SlasherBloodTrailSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movement = default!; // Ratbite
 
     // Next time at which we should drop a blood puddle for an entity.
     private readonly Dictionary<EntityUid, TimeSpan> _nextDropAt = new();
@@ -33,6 +35,7 @@ public sealed class SlasherBloodTrailSystem : EntitySystem
         SubscribeLocalEvent<SlasherBloodTrailComponent, ToggleBloodTrailEvent>(OnToggle);
 
         SubscribeLocalEvent<SlasherBloodTrailComponent, SlasherIncorporealizeDoAfterEvent>(OnIncorporealize);
+        SubscribeLocalEvent<SlasherBloodTrailComponent, RefreshMovementSpeedModifiersEvent>(OnMovementSpeedRefresh); // Ratbite
     }
 
     private void OnMapInit(Entity<SlasherBloodTrailComponent> ent, ref MapInitEvent args)
@@ -77,7 +80,7 @@ public sealed class SlasherBloodTrailSystem : EntitySystem
             _nextDropAt.Remove(ent.Owner);
             StopFunkyslasher(ent.Owner, ent.Comp); // Aura loss
         }
-
+        _movement.RefreshMovementSpeedModifiers(ent.Owner, null); // Ratbite
         args.Handled = true;
     }
 
@@ -146,4 +149,12 @@ public sealed class SlasherBloodTrailSystem : EntitySystem
 
         comp.FunkyslasherStream = _audio.Stop(comp.FunkyslasherStream);
     }
+
+    // <Ratbite> - Made blood trail not pure larp (movement speed buff), slasher doesnt have aura anyway
+    private void OnMovementSpeedRefresh(Entity<SlasherBloodTrailComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
+    {
+        if (ent.Comp.IsActive)
+            args.ModifySpeed(ent.Comp.BloodTrailMovementBonus, ent.Comp.BloodTrailMovementBonus);;
+    }
+    // </Ratbite>
 }

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherIncorporealSystem.cs
@@ -509,7 +509,7 @@ public sealed class SlasherIncorporealSystem : EntitySystem
 
     private bool IsInsideSolidObject(EntityUid uid)
     {
-        var entities = _lookup.GetEntitiesInRange(uid, 1f, LookupFlags.Static | LookupFlags.Sundries);
+        var entities = _lookup.GetEntitiesInRange(uid, 0.4f, LookupFlags.Static | LookupFlags.Sundries); // Ratbite - lowered checking range, should still not let you corporealize inside walls while not being extremely limiting 
 
         foreach (var entity in entities)
         {

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
@@ -53,7 +53,7 @@ public sealed class SlasherRegenerateSystem : EntitySystem
             return;
 
         // Check if a soul is available to use
-        if (!comp.HasSoulAvailable)
+        if (comp.SoulsAvailable <= 0) // Ratbite - made storing souls possible in exchange for removing possession
         {
             _popup.PopupPredicted(Loc.GetString("slasher-regenerate-no-soul"), uid, uid);
             return;
@@ -79,7 +79,7 @@ public sealed class SlasherRegenerateSystem : EntitySystem
         _audio.PlayPredicted(comp.RegenerateSound, uid, uid);
 
         // Consume the soul
-        comp.HasSoulAvailable = false;
+        comp.SoulsAvailable--; // Ratbite - made storing souls possible in exchange for removing possession
         Dirty(uid, comp);
 
         args.Handled = true;
@@ -108,8 +108,11 @@ public sealed class SlasherRegenerateSystem : EntitySystem
     {
         if (!Resolve(uid, ref comp))
             return;
-
-        comp.HasSoulAvailable = true;
+        // <Ratbite> - made storing souls possible in exchange for removing possession
+        if (comp.SoulsAvailable >= 3) // 3 souls storage max
+            return;
+        comp.SoulsAvailable++;
+        // </Ratbite>
         Dirty(uid, comp);
     }
 }

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
@@ -79,7 +79,14 @@ public sealed class SlasherRegenerateSystem : EntitySystem
         _audio.PlayPredicted(comp.RegenerateSound, uid, uid);
 
         // Consume the soul
-        comp.SoulsAvailable--; // Ratbite - made storing souls possible in exchange for removing possession
+        // <Ratbite> - made storing souls possible in exchange for removing possession
+        comp.SoulsAvailable--;
+
+        if (comp.SoulsAvailable == 0)
+            _popup.PopupPredicted(Loc.GetString("slasher-regenerate-soul-emptied"), uid, uid, PopupType.MediumCaution);
+
+        // </Ratbite>
+
         Dirty(uid, comp);
 
         args.Handled = true;
@@ -108,11 +115,14 @@ public sealed class SlasherRegenerateSystem : EntitySystem
     {
         if (!Resolve(uid, ref comp))
             return;
+
         // <Ratbite> - made storing souls possible in exchange for removing possession
         if (comp.SoulsAvailable >= comp.MaxSouls)
             return;
+
         comp.SoulsAvailable++;
         // </Ratbite>
+
         Dirty(uid, comp);
     }
 }

--- a/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
+++ b/Content.Goobstation.Shared/Slasher/Systems/SlasherRegenerateSystem.cs
@@ -109,7 +109,7 @@ public sealed class SlasherRegenerateSystem : EntitySystem
         if (!Resolve(uid, ref comp))
             return;
         // <Ratbite> - made storing souls possible in exchange for removing possession
-        if (comp.SoulsAvailable >= 3) // 3 souls storage max
+        if (comp.SoulsAvailable >= comp.MaxSouls)
             return;
         comp.SoulsAvailable++;
         // </Ratbite>

--- a/Resources/Locale/en-US/_Goobstation/slasher/slasher.ftl
+++ b/Resources/Locale/en-US/_Goobstation/slasher/slasher.ftl
@@ -12,6 +12,7 @@ slasher-staggerarea-victim = A horrifying chill runs down your spine!
 slasher-staggerarea-popup = You unleash a wave of terror.
 
 slasher-regenerate-no-soul = You need a stolen soul to regenerate!
+slasher-regenerate-soul-emptied = That was the last soul in your buffer.
 
 slasher-soulsteal-success = You feel a dark energy course through you.
 slasher-soulsteal-start = You begin to siphon the life force of your victim...

--- a/Resources/Prototypes/Actions/slasher.yml
+++ b/Resources/Prototypes/Actions/slasher.yml
@@ -54,7 +54,7 @@
 - type: entity
   id: ActionSlasherBloodTrail
   name: Blood Trail
-  description: Begin trailing blood in your wake with some funky music. Spooky!
+  description: Begin trailing blood in your wake with some funky music. Makes you faster. Spooky!
   components:
   - type: Action
     raiseOnUser: true

--- a/Resources/Prototypes/Actions/slasher.yml
+++ b/Resources/Prototypes/Actions/slasher.yml
@@ -65,28 +65,29 @@
   - type: InstantAction
     event: !type:ToggleBloodTrailEvent
 
-- type: entity
-  id: ActionSlasherPossession
-  name: Possession
-  description: Use this on a person to begin to exact your control on them, giving you temporary control of their body for 45 seconds. Once time is up, both bodies return.
-  components:
-  - type: Action
-    raiseOnUser: true
-    useDelay: 180
-    checkCanInteract: false
-    itemIconStyle: BigAction
-    icon: { sprite: _Goobstation/Actions/slashericons.rsi, state: Possession }
-  - type: TargetAction
-    range: 3.5
-    interactOnMiss: false
-  - type: EntityTargetAction
-    canTargetSelf: false
-    event: !type:SlasherPossessionEvent
+# Ratbite - Removed possession in favor of regeneration being able to store souls
+#- type: entity
+#  id: ActionSlasherPossession
+#  name: Possession
+#  description: Use this on a person to begin to exact your control on them, giving you temporary control of their body for 45 seconds. Once time is up, both bodies return.
+#  components:
+#  - type: Action
+#    raiseOnUser: true
+#    useDelay: 180
+#    checkCanInteract: false
+#    itemIconStyle: BigAction
+#    icon: { sprite: _Goobstation/Actions/slashericons.rsi, state: Possession }
+#  - type: TargetAction
+#    range: 3.5
+#    interactOnMiss: false
+#  - type: EntityTargetAction
+#    canTargetSelf: false
+#    event: !type:SlasherPossessionEvent
 
 - type: entity
   id: ActionSlasherRegenerate
   name: Regenerate
-  description: Quickly regenerate your being, restoring all lost health, repairing wounds, and removing all stuns. Must be recharged by stealing a soul after every use.
+  description: Quickly regenerate your being, restoring all lost health, repairing wounds, and removing all stuns. Steal souls to gain more uses, capped at 3 uses at a time. # Ratbite
   components:
   - type: Action
     raiseOnUser: true

--- a/Resources/Prototypes/Actions/slasher.yml
+++ b/Resources/Prototypes/Actions/slasher.yml
@@ -87,7 +87,7 @@
 - type: entity
   id: ActionSlasherRegenerate
   name: Regenerate
-  description: Quickly regenerate your being, restoring all lost health, repairing wounds, and removing all stuns. Steal souls to gain more uses, capped at 3 uses at a time. # Ratbite
+  description: Quickly regenerate your being, restoring all lost health, repairing wounds, and removing all stuns. Consume souls to gain more uses, capped at 3 uses at a time. # Ratbite
   components:
   - type: Action
     raiseOnUser: true


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Slasher's regenerate ability can now store up to 3 souls for later use
Blood trail ability now speeds the slasher up by 1.15x
Corporealization can now be done in 1x1 spaces
Removed possession ability
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Possession is bullshit.
Yeah sure you can counter it, but that sacrifices your head slot.. and then the slasher decides to aim head.. and now you're decapitated. And no one would want to mindshield themselves. And security will go in alone and die. Its inevitable. Also I died to it as a loneop (after i killed all of sec and armed the nuke) so I must mald :godo: :godo:


and blood trail was purely a larp/"aura" ability that served no purpose in life, its only purpose in life was sitting on that action bar, occupying that slot daily. It was nothing. It served 0 purpose. It should have killed itself, NOW.
it now has a purpose of either running away when spotted or chasing a victim already aware of your presence! neat
## Technical details
<!-- Summary of code changes for easier review. -->
Commented out everything related to the actual YAML part of Possession

Added `SoulsAvailable` and `MaxSouls` components for regenerate

Added `BloodTrailMovementBonus` component for blood trail, made toggling blood trail run the movement speed refresh event, made it apply the movement speed (duh)
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/2d5a3a56-a990-46f5-8a9d-f420d2ec755a


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Slasher's blood trail ability now increases your movement speed
- tweak: Slasher's regenerate ability can now store up to three souls
- tweak: Slasher can now corporealize in 1x1 spaces
- remove: Slasher's possession ability
