### PR TITLE
Allow NTR to perform terminations with brig time

### DIFF
--- a/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationComponent.cs
+++ b/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationComponent.cs
@@ -1,0 +1,49 @@
+using Robust.Shared.Network;
+
+namespace Content.Server._BRatbite.PermaBrig.NTRTermination;
+
+[RegisterComponent]
+// Entities with this component are able to fill and send termination requests
+public sealed partial class NTRTerminationComponent : Component;
+
+[RegisterComponent]
+public sealed partial class NTRTerminationPaperComponent : Component
+{
+    [DataField]
+    public TimeSpan AddedTime = TimeSpan.FromMinutes(60);
+
+    [DataField]
+    public NetUserId? Terminator;
+
+    [DataField]
+    public NetUserId? TerminatedUser;
+
+    [DataField]
+    public List<string> AcceptedStamps = new List<string> { "stamp-component-stamped-name-captain", "stamp-component-stamped-name-hop" };
+
+    [DataField]
+    // If not null, this has been forged
+    public NetUserId? ForgedBy;
+
+    [DataField]
+    public LocId AcceptedMessage = "ntr-termination-accept-message";
+
+    [DataField]
+    public LocId ForgedMessage = "ntr-termination-forged-message";
+
+    [DataField]
+    public LocId AcceptedStampName = "ntr-termination-accept-stamp";
+
+    [DataField]
+    public Color AcceptedStampColor = new(0x00, 0x66, 0x00); // same as centcom
+}
+
+[RegisterComponent]
+// Component given to all command roles, indicating that they can be terminated
+public sealed partial class NTRTerminatableComponent : Component
+{
+    [DataField]
+    public NetUserId? LastMind; // Indicates last mind of this user so
+                                // that if the player ghosts/suicides
+                                // they can still be terminated
+}

--- a/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
@@ -1,0 +1,141 @@
+using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
+using Content.Shared.Interaction;
+using Content.Shared.Mind;
+using Content.Shared.Popups;
+using Content.Shared.Mind.Components;
+using Content.Goobstation.Shared.Fax;
+using Content.Shared.Paper;
+using System.Linq;
+using Content.Server.Fax;
+using Content.Shared.Fax.Components;
+using Content.Server.Administration.Notes;
+using Robust.Shared.Player;
+using Robust.Shared.Network;
+using Content.Shared.Database;
+using System.Threading.Tasks;
+
+namespace Content.Server._BRatbite.PermaBrig.NTRTermination;
+
+public sealed partial class NTRTerminationSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly SharedCuffableSystem _cuffableSystem = default!;
+    [Dependency] private readonly PermaBrigManager _permaBrigManager = default!;
+    [Dependency] private readonly FaxSystem _faxSystem = default!;
+    [Dependency] private readonly IAdminNotesManager _adminNotesManager = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<NTRTerminatableComponent, MindAddedMessage>(OnMindAdded);
+        SubscribeLocalEvent<NTRTerminatableComponent, MapInitEvent>(OnMapInit);
+
+        SubscribeLocalEvent<NTRTerminationPaperComponent, AfterInteractEvent>(OnInteract);
+        SubscribeLocalEvent<NTRTerminationPaperComponent, GettingFaxedSentEvent>(OnGettingFaxed);
+        SubscribeLocalEvent<NTRTerminationPaperComponent, InteractUsingEvent>(OnInteractUsing);
+        base.Initialize();
+    }
+
+    private void OnInteract(Entity<NTRTerminationPaperComponent> ent, ref AfterInteractEvent args)
+    {
+        if (!args.CanReach || args.Handled || args.Target is not { } target) return;
+        if (!HasComp<NTRTerminationComponent>(args.User))
+        {
+            _popup.PopupEntity(Loc.GetString("ntr-termination-only-ntr"), args.User, args.User);
+            return;
+        }
+
+        if (!TryComp<NTRTerminatableComponent>(args.Target, out var ntrTerminatable) || ntrTerminatable.LastMind is not { } userId)
+        {
+            _popup.PopupEntity(Loc.GetString("ntr-termination-only-command"), args.User, args.User);
+            return;
+        }
+
+        if (TryComp<CuffableComponent>(target, out var cuffableComp) && !_cuffableSystem.IsCuffed((target, cuffableComp)))
+        {
+            _popup.PopupEntity(Loc.GetString("ntr-termination-need-cuff"), args.User, args.User);
+            return;
+        }
+
+        if (!_mindSystem.TryGetMind(args.User, out _, out var mind) || mind.UserId is not { } terminator) return;
+
+        ent.Comp.Terminator = terminator;
+        ent.Comp.TerminatedUser = userId;
+        _popup.PopupEntity(Loc.GetString("ntr-termination-victim-success"), args.User);
+        args.Handled = true;
+    }
+
+    private void OnMindAdded(Entity<NTRTerminatableComponent> ent, ref MindAddedMessage args)
+    {
+        ent.Comp.LastMind = args.Mind.Comp.UserId;
+    }
+
+    private void OnMapInit(Entity<NTRTerminatableComponent> ent, ref MapInitEvent args)
+    {
+        _mindSystem.TryGetMind(ent, out _, out var mindComp);
+        ent.Comp.LastMind = mindComp?.UserId;
+    }
+
+    private void OnGettingFaxed(Entity<NTRTerminationPaperComponent> ent, ref GettingFaxedSentEvent args)
+    {
+        if (ent.Comp.TerminatedUser is not { } user) return;
+        if (!TryComp<PaperComponent>(ent, out var paper)) return;
+        if (ent.Comp.Terminator is not { } terminator) return;
+        if (ent.Comp.ForgedBy is { } forgedBy)
+        {
+            args.Handled = true;
+            ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.ForgedMessage));
+            _permaBrigManager.AddBrigTime(forgedBy, (int) ent.Comp.AddedTime.TotalMinutes * 3);
+            AddAdminRemark(terminator, terminator, Loc.GetString("ntr-termination-forge-admin-remark"));
+            RemComp<NTRTerminationPaperComponent>(ent);
+            return;
+        }
+        var isStamped = ent.Comp.AcceptedStamps.Any(
+            locId => paper.StampedBy.Select(p => p.StampedName).Contains(locId)
+        );
+        if (!isStamped) return;
+        ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.AcceptedMessage));
+        _permaBrigManager.AddBrigTime(user, (int) ent.Comp.AddedTime.TotalMinutes);
+        AddAdminRemark(terminator, user, Loc.GetString("ntr-termination-success-admin-remark"));
+        // Remove component so they can't brig the same person again
+        RemComp<NTRTerminationPaperComponent>(ent);
+        args.Handled = true;
+    }
+
+    private void ReceiveFax(Entity<NTRTerminationPaperComponent> ent, EntityUid fax, string message)
+    {
+        _faxSystem.Receive(
+            fax,
+            new FaxPrintout(
+                message,
+                new(),
+                Loc.GetString("ntr-termination-paper-name"),
+                stampState: "paper_stamp-centcom",
+                stampedBy: new List<StampDisplayInfo> {
+                    new StampDisplayInfo {
+                        StampedName = ent.Comp.AcceptedStampName,
+                        StampedColor = ent.Comp.AcceptedStampColor
+                    }
+                }
+            )
+        );
+    }
+
+    private void AddAdminRemark(NetUserId sender, NetUserId target, string message)
+    {
+        var session = _playerMan.GetSessionById(sender);
+        Task.Run(() => _adminNotesManager.AddAdminRemark(session, target, NoteType.Note, message, NoteSeverity.Minor, false, null)).GetAwaiter().GetResult();
+    }
+
+    private void OnInteractUsing(Entity<NTRTerminationPaperComponent> ent, ref InteractUsingEvent args)
+    {
+        if (!TryComp<StampComponent>(args.Used, out var stampComp) || !HasComp<NTRTerminationComponent>(args.User)) return;
+        if (ent.Comp.AcceptedStamps.Contains(stampComp.StampedName) && _mindSystem.TryGetMind(args.User, out _, out var mind))
+        {
+            // NTR is a moron and is trying to forge the stamp
+            ent.Comp.ForgedBy = mind.UserId;
+        }
+    }
+}

--- a/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
@@ -48,15 +48,15 @@ public sealed partial class NTRTerminationSystem : EntitySystem
             return;
         }
 
-        if (!TryComp<NTRTerminatableComponent>(args.Target, out var ntrTerminatable) || ntrTerminatable.LastMind is not { } userId)
-        {
-            _popup.PopupEntity(Loc.GetString("ntr-termination-only-command"), args.User, args.User);
-            return;
-        }
-
         if (TryComp<CuffableComponent>(target, out var cuffableComp) && !_cuffableSystem.IsCuffed((target, cuffableComp)))
         {
             _popup.PopupEntity(Loc.GetString("ntr-termination-need-cuff"), args.User, args.User);
+            return;
+        }
+
+        if (!TryComp<NTRTerminatableComponent>(args.Target, out var ntrTerminatable) || ntrTerminatable.LastMind is not { } userId)
+        {
+            _popup.PopupEntity(Loc.GetString("ntr-termination-only-command"), args.User, args.User);
             return;
         }
 
@@ -100,7 +100,7 @@ public sealed partial class NTRTerminationSystem : EntitySystem
         if (!isStamped) return;
 
         var reasonForDemotion = FindReasonOfDemotion(paper.Content);
-        
+
         ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.AcceptedMessage, [("reason", reasonForDemotion)]));
         _permaBrigManager.AddBrigTime(user, (int) ent.Comp.AddedTime.TotalMinutes);
         AddAdminRemark(terminator, user, Loc.GetString("ntr-termination-success-admin-remark", [("reason", reasonForDemotion)]));
@@ -160,7 +160,7 @@ public sealed partial class NTRTerminationSystem : EntitySystem
 
     private void OnPaperInit(Entity<NTRTerminationPaperComponent> ent, ref MapInitEvent args)
     {
-        if(!TryComp<PaperComponent>(ent, out var paper)) return;
+        if (!TryComp<PaperComponent>(ent, out var paper)) return;
         paper.Content += '\n' + Loc.GetString("ntr-termination-paper-reson-for-demotion");
     }
 }

--- a/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/NTRTermination/NTRTerminationSystem.cs
@@ -32,6 +32,7 @@ public sealed partial class NTRTerminationSystem : EntitySystem
         SubscribeLocalEvent<NTRTerminatableComponent, MindAddedMessage>(OnMindAdded);
         SubscribeLocalEvent<NTRTerminatableComponent, MapInitEvent>(OnMapInit);
 
+        SubscribeLocalEvent<NTRTerminationPaperComponent, MapInitEvent>(OnPaperInit);
         SubscribeLocalEvent<NTRTerminationPaperComponent, AfterInteractEvent>(OnInteract);
         SubscribeLocalEvent<NTRTerminationPaperComponent, GettingFaxedSentEvent>(OnGettingFaxed);
         SubscribeLocalEvent<NTRTerminationPaperComponent, InteractUsingEvent>(OnInteractUsing);
@@ -88,7 +89,8 @@ public sealed partial class NTRTerminationSystem : EntitySystem
             args.Handled = true;
             ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.ForgedMessage));
             _permaBrigManager.AddBrigTime(forgedBy, (int) ent.Comp.AddedTime.TotalMinutes * 3);
-            AddAdminRemark(terminator, terminator, Loc.GetString("ntr-termination-forge-admin-remark"));
+            // Terminator and forgedBy will pretty much always be the same person
+            AddAdminRemark(terminator, forgedBy, Loc.GetString("ntr-termination-forge-admin-remark"));
             RemComp<NTRTerminationPaperComponent>(ent);
             return;
         }
@@ -96,12 +98,29 @@ public sealed partial class NTRTerminationSystem : EntitySystem
             locId => paper.StampedBy.Select(p => p.StampedName).Contains(locId)
         );
         if (!isStamped) return;
-        ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.AcceptedMessage));
+
+        var reasonForDemotion = FindReasonOfDemotion(paper.Content);
+        
+        ReceiveFax(ent, args.Fax, Loc.GetString(ent.Comp.AcceptedMessage, [("reason", reasonForDemotion)]));
         _permaBrigManager.AddBrigTime(user, (int) ent.Comp.AddedTime.TotalMinutes);
-        AddAdminRemark(terminator, user, Loc.GetString("ntr-termination-success-admin-remark"));
+        AddAdminRemark(terminator, user, Loc.GetString("ntr-termination-success-admin-remark", [("reason", reasonForDemotion)]));
         // Remove component so they can't brig the same person again
         RemComp<NTRTerminationPaperComponent>(ent);
         args.Handled = true;
+    }
+
+    private string FindReasonOfDemotion(string content)
+    {
+        var reasonField = Loc.GetString("ntr-termination-paper-reson-for-demotion");
+        var startIndex = content.IndexOf(reasonField);
+        if (startIndex == -1) // NTR messed up the form, I guess take the last line
+        {
+            var line = content.Split("\n").LastOrDefault((l) => l.Trim().Length > 0) ?? "";
+            return line.Substring(0, Math.Min(300, line.Length));
+        }
+        var field = content.Substring(startIndex + reasonField.Length);
+        var result = (string.Join("\n", field.Split("\n").Take(3))).Trim();
+        return result.Substring(0, Math.Min(300, result.Length));
     }
 
     private void ReceiveFax(Entity<NTRTerminationPaperComponent> ent, EntityUid fax, string message)
@@ -137,5 +156,11 @@ public sealed partial class NTRTerminationSystem : EntitySystem
             // NTR is a moron and is trying to forge the stamp
             ent.Comp.ForgedBy = mind.UserId;
         }
+    }
+
+    private void OnPaperInit(Entity<NTRTerminationPaperComponent> ent, ref MapInitEvent args)
+    {
+        if(!TryComp<PaperComponent>(ent, out var paper)) return;
+        paper.Content += '\n' + Loc.GetString("ntr-termination-paper-reson-for-demotion");
     }
 }

--- a/Resources/Locale/en-US/_BRatbite/ntr-termination.ftl
+++ b/Resources/Locale/en-US/_BRatbite/ntr-termination.ftl
@@ -1,0 +1,25 @@
+ntr-termination-only-ntr = Only NTR can use this.
+ntr-termination-only-command = You can only use it on heads of staff.
+ntr-termination-need-cuff = You need to restrain them first.
+ntr-termination-victim-success = You successfully got their info on the microchip
+ntr-termination-forge-admin-remark = **Automated Perma** +3 permas for attempting to forge NTR termination document.
+ntr-termination-success-admin-remark = **Automated Perma** +1 perma for being demoted as a head of staff by NTR.
+ntr-termination-paper-name = Centcom Correspondence
+ntr-termination-forged-message =
+    Our advanced systems have detected that you have attempted to forge this document.
+    This action will be punished.
+ntr-termination-accept-message =
+    The report has been accepted and processed. The head of staff will be punished.
+    Glory to Nanotrasen
+ntr-termination-paper-content =
+    {"["}color=#1b67a5]░░██░░ [head=2]Official Document[/head]
+    ▀████▀ [head=3]Subject: NTR Termination Request[/head]
+    ▄█▀▀█▄ [head=3]To: Central Command[/head]
+    {"["}/color]──────────────────────────────────────
+    {"["}bold]Purpose:[/bold] This document authorizes the termination of a member of Command and their sentencing to one (1) hour of detainment. It is to be filled out and processed only by an on-station Nanotrasen Representative.
+    {"["}bold]Procedure:[/bold]
+    • [bold]Restrain[/bold] (or get security to restrain) the offending head of staff.
+    • [bold]Interact with them with this document[/bold] to transfer their credentials via embedded nanochip.
+    • [bold]Get this document stamped by the Captain or HoP[/bold]. And have them remove the access from the offending member as outlined in the SoP.
+    • [bold]Fax this document to Central Command[/bold]. Upon doing so, if the procedure was followed correctly, you will receive an automated message of approval.
+ntr-termination-accept-stamp = Centcom Automation

--- a/Resources/Locale/en-US/_BRatbite/ntr-termination.ftl
+++ b/Resources/Locale/en-US/_BRatbite/ntr-termination.ftl
@@ -2,14 +2,17 @@ ntr-termination-only-ntr = Only NTR can use this.
 ntr-termination-only-command = You can only use it on heads of staff.
 ntr-termination-need-cuff = You need to restrain them first.
 ntr-termination-victim-success = You successfully got their info on the microchip
-ntr-termination-forge-admin-remark = **Automated Perma** +3 permas for attempting to forge NTR termination document.
-ntr-termination-success-admin-remark = **Automated Perma** +1 perma for being demoted as a head of staff by NTR.
+ntr-termination-forge-admin-remark = **Automated Perma** +3 permas for attempting to forge an NTR termination document.
+ntr-termination-success-admin-remark =
+    {"*"}*Automated Perma** +1 perma for being demoted as a head of staff by NTR.
+    Detected reason: {$reason}
 ntr-termination-paper-name = Centcom Correspondence
 ntr-termination-forged-message =
     Our advanced systems have detected that you have attempted to forge this document.
     This action will be punished.
 ntr-termination-accept-message =
     The report has been accepted and processed. The head of staff will be punished.
+    The detected reason for demotion is: {$reason}
     Glory to Nanotrasen
 ntr-termination-paper-content =
     {"["}color=#1b67a5]░░██░░ [head=2]Official Document[/head]
@@ -22,4 +25,9 @@ ntr-termination-paper-content =
     • [bold]Interact with them with this document[/bold] to transfer their credentials via embedded nanochip.
     • [bold]Get this document stamped by the Captain or HoP[/bold]. And have them remove the access from the offending member as outlined in the SoP.
     • [bold]Fax this document to Central Command[/bold]. Upon doing so, if the procedure was followed correctly, you will receive an automated message of approval.
+    ──────────────────────────────────────
+    {"["}bold]Name of terminated staff:[/bold]
+    {"["}bold]Job to be terminated from:[/bold]
+ntr-termination-paper-reson-for-demotion = [bold]Reason for demotion:[/bold]
 ntr-termination-accept-stamp = Centcom Automation
+

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -171,6 +171,7 @@
     components:
       - type: CommandStaff
       - type: QuartermasterTraining
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: QuartermasterGear

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -185,6 +185,7 @@
       - type: Condemned # Goobstation - Nanotrasen owns your soul pal.
         soulOwnedNotDevil: true
       - type: CombatTrained # Ratbite
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: CaptainGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -198,6 +198,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: HoPGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -177,6 +177,7 @@
     components:
       - type: CommandStaff
       - type: EngineeringStaff # Goobstation
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: ChiefEngineerGear

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -172,6 +172,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: NTRTerminatable # Ratbite
   # Shitmed Change
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -171,6 +171,7 @@
   - !type:AddComponentSpecial
     components:
       - type: CommandStaff
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: ResearchDirectorGear

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -185,6 +185,7 @@
       - type: CommandStaff
       - type: SecurityStaff # goobstation
       - type: CombatTrained
+      - type: NTRTerminatable # Ratbite
 
 - type: startingGear
   id: HoSGear

--- a/Resources/Prototypes/_BRatbite/Entities/Unique/demotion_papers.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Unique/demotion_papers.yml
@@ -1,0 +1,20 @@
+- type: entity
+  id: FolderCentcomDemotion
+  parent: BoxFolderCentCom
+  name: Termination Papers Folder
+  description: Terminate incompetent heads of staff with this!
+  components:
+  - type: StorageFill
+    contents:
+      - id: DemotionPaper
+        prob: 1
+
+- type: entity
+  id: DemotionPaper
+  parent: Paper
+  name: Termination Papers
+  description: Terminate incompetent heads of staff with this!
+  components:
+  - type: Paper
+    content: ntr-termination-paper-content
+  - type: NTRTerminationPaper

--- a/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/Fills/Lockers/heads.yml
@@ -23,7 +23,8 @@
   id: LockerFillNanorep
   table: !type:AllSelector
     children:
-    - id: BoxFolderCentCom
+    # - id: BoxFolderCentCom # Ratbite replace with demotion papers
+    - id: FolderCentcomDemotion
     # - id: BriefcaseBrownFilled
     - id: WeaponDisablerAdvanced
     - id: BedsheetCentcom

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Dignitary/nanotrasen_representative.yml
@@ -147,6 +147,7 @@
       - type: CommandStaff
       - type: Condemned
         soulOwnedNotDevil: true
+      - type: NTRTermination # Ratbite
 
 - type: startingGear
   id: NanotrasenRepresentativeGear


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Allow the NTR to perform special demotions on heads of staff (Command members, not including RSO, BSO, NTR themselves and Warden). When completed successfully, these demotions will automatically give 1 hour of perma time to the head of staff.
To do so, the NTR must:
- Take the demotion paper from their locker. (Only the NTR can use this special form)
- Have the offending head of staff restrained
- Touch the head of staff with the form, while they are cuffed
- Get the form stamped by the HoP or Captain (And access removed, but this is not required for the system to work). If the NTR attempts to forge this stamp, they will automatically get 3 permas instead.
- Fax the form
Upon faxing the form, if the above procedures were followed correctly, they will get a confirmation from the automated Centcom system, the form will lose its ability to hand out any more permas, and an admin note will be added to the head of staff.
The NTR only has one of these forms, and cannot get more without admin intervention.

## Why / Balance
I think this goes well with the main philosophy of ratbite, that is minimal admin intervention, allowing the NTR to punish people IC, without giving them too much power (only one perma per round). 
This is not a replacement for CR1, while the NTR needs to have a valid reasoning, they should have more freedom than admins in giving these. This is countered by the fact that it all needs to happen IC, so death of the NTR, losing the termination paper, the captain or hop refusing to stamp or demote, or even the offending head launching themselves in space will render it impossible to be applied. Also repeated offending will not multiply because it's a different system than CRs.


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="521" height="622" alt="image" src="https://github.com/user-attachments/assets/21fc6bc4-2fe6-497b-91bd-3c03ab276a10" />
<img width="516" height="619" alt="image" src="https://github.com/user-attachments/assets/55ce246c-2238-4eab-8c7d-dbeefed4cd7e" />
<img width="603" height="108" alt="image" src="https://github.com/user-attachments/assets/afb21dc8-ca80-4169-84e0-fbe6b6494554" />
<img width="439" height="55" alt="image" src="https://github.com/user-attachments/assets/a85cb4e8-da07-4dda-85da-ef60f64720f5" />
<img width="433" height="515" alt="image" src="https://github.com/user-attachments/assets/456dc033-bd88-4fe4-bd84-fe83535b3d08" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: NTR terminations
