### PR TITLE
actual proper PKA nerf/rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -609,9 +609,9 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 8 # Ratbite kill dam
+        Blunt: 15 # Ratbite - bevv the base PKA is NOT meta, stop nerfing it for fucks sake..
         Structural: 20 # Ratbite re add
-        armorPenetration: -0.5 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
+      armorPenetration: -0.5 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
   # Short lifespan
   - type: TimedDespawn
     lifetime: 0.22 # roughly 5.5 tiles

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -31,8 +31,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 4 #Ratbite kill
-        armorPenetration: -0.5 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
+        Blunt: 8 # Ratbite - this is for the PK repeater, it was literally the worst PKA option during the height of the PK pistol meta and still is, buff offmeta a bit :godo:
+      armorPenetration: -0.5 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
 
 - type: entity
   id: WeakBulletKinetic
@@ -43,8 +43,8 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 4 #Ratbite kill
-        armorPenetration: -0.5 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
+        Blunt: 6 #Ratbite kill
+      armorPenetration: -0.65 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
 
 - type: entity
   id: PelletKinetic

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -43,7 +43,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 6 #Ratbite kill
+        Blunt: 4 #Ratbite kill
       armorPenetration: -0.65 # Ratbite, balance against antags/sec still a murder weapon keep away from tidas
 
 - type: entity

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -60,7 +60,7 @@
   - type: GunUpgradeDamage
     damage:
       types:
-        Blunt: 10
+        Blunt: 4
 
 - type: entity
   id: PKAUpgradeRange

--- a/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Objects/Weapons/pka_upgrade.yml
@@ -60,7 +60,7 @@
   - type: GunUpgradeDamage
     damage:
       types:
-        Blunt: 4
+        Blunt: 4 # Ratbite - balance
 
 - type: entity
   id: PKAUpgradeRange


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Lowered damage upgrade damage increase to 4 (from 10)
~~Slighly increased PKP(istol) and PKS base damage (6, from 4)~~
Slighly lowered PKP and PKS armor piercing to -0.65 (from -0.5)
Increased base PKA damage to 15 (from 8)
Increased PKR damage to 8 (from 4)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Decreasing base damage was just making the difference between PKP and literally every other proto-kinetic weapon WAY larger due to the fact that the PKA has 200 upgrade limit
So, instead of doing that, just make the damage upgrade do less.
The PKP (2 firerate upgrades), PKR (1 damage upgrade) and PKP (1 damage upgrade, 4 firerate upgrades) now have a similar TTK for naked people (~3 seconds)
PKS (1 damage upgrade) is somewhat better point blank but otherwise its similar, if not somewhat worse perfoming overall
PKS takes 6 meatshots (~10 seconds) to down a secoff with an armor vest
PKA takes ~14 seconds
PKR takes ~16 seconds
PKP takes ~11 seconds

###### (yknow we could merge LL 1.5 to get more modern goob PKA's.. that wont have this problem of having removed pressure limits from old PKA's and NOT reverting it...)
## Technical details
<!-- Summary of code changes for easier review. -->
YAML
also bevv you didnt do the indents on `armorPenetration` properly, it wasnt applying :godo:
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

FUCK i forgot to make a before.. and its 1am for me already.. :joel:

and approximately 20 hours later i have decided im too lazy to do the before part so i'll just drop the approximate DPS on unarmored targets for BEFORE: (after the last bevv nerf; PKA 8 and PKR,PKS,PKP 4 damage base, damage modkit does +10)
PKA (1 damage, 1 firerate) (18, 1.05shots/s) ~= 20DPS, 5s TTK
PKR (1 damage) (14 damage, ~0.7shots/s) ~= 18DPS, ~5s TTK
PKS (1 damage) (10x6 damage, 0.7shots/s ~= 45DPS pointblank, 20DPS ~3 tiles away, ~2-5s TTK
PKP (2 damage, 3 firerate) (22 damage, 2.3shots/s) ~= 50DPS, 2s TTK

AFTER (a bit outdated, assume about 1/5 lower TTK's for both the shotgun and pistol):

https://github.com/user-attachments/assets/70669526-36cd-44c8-99a8-582e221a2a31

(it looks like shit because it needs to be under 10MB to be uploadable directly to github..)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The PKA damage modkit now increases damage less (4, used to be 10)
- tweak: Increased PKA damage from 8 to 15
- tweak: Increased PKR damage from 4 to 8
- tweak: PKP and the PKS are now more affected by armor
- remove: Removed Herobrine
