### PR TITLE
reenable salv shuttle

### DIFF
--- a/Resources/Prototypes/_Lavaland/Entities/Structures/airlocks.yml
+++ b/Resources/Prototypes/_Lavaland/Entities/Structures/airlocks.yml
@@ -38,11 +38,10 @@
   components:
   - type: PriorityDock
     tag: DockMining
- # - type: GridFill
- #   path: /Maps/_Lavaland/mining.yml
- #   addComponents:
- #   - type: IFF
- #     flags:
- #     - HideLabel
+  - type: GridFill
+    path: /Maps/_Lavaland/mining.yml
+    addComponents:
+    - type: IFF
+      flags:
+      - HideLabel
 
- # Ratbite, testing to see if making salv work up to lavaland via teleporter helps self antag slop.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
reenabled salv LL shuttle
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
https://youtu.be/k1BneeJTDcU?t=231
could i interest you in LL, all of the time?
a little bit of LL, all of the time?
VGRoid is a tragedy <sup><sub>(in content)</sub></sup> and space salv is ass <sup>(you cant really deny this one)</sup>
a little bit of LL, ***all of the time?***

<br>
syndiebase is already neutered and undetectable on mass scanner, salv selfantag slop shouldnt be that much of an issue anymore (we were kind of getting the opposite of that with lack of PKA pressure, most salvs (including me :godo:) were validhunting instead of selfantagging :godo:)

#476 also has this change but i doubt its getting merged so i opened this instead
:godo:
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<details>
<summary> I attached Media at 3 AM!! (SHOCKING) (POLICE WERE CALLED) </summary>

<img width="1100" height="724" alt="image" src="https://github.com/user-attachments/assets/bfd16e62-a316-4265-a83a-320f09a0557e" />
<img width="1100" height="724" alt="image" src="https://github.com/user-attachments/assets/885f2cad-305e-450d-b1b6-51a14a4bac08" />
<img width="1100" height="724" alt="image" src="https://github.com/user-attachments/assets/6d1ef188-62d0-43f9-b992-9372ce1df4c7" />
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Readded salvage shuttle
- remove: Removed Herobrine
