### PR TITLE
Fix one source of NaN bug

### DIFF
--- a/Content.Client/Power/Battery/BatteryBoundUserInterface.cs
+++ b/Content.Client/Power/Battery/BatteryBoundUserInterface.cs
@@ -46,10 +46,10 @@ public sealed class BatteryBoundUserInterface : BoundUserInterface, IBuiPreTickU
 
     void IBuiPreTickUpdate.PreTickUpdate()
     {
-        if (_chargeRateCoalescer.CheckIsModified(out var chargeRateValue))
+        if (_chargeRateCoalescer.CheckIsModified(out var chargeRateValue) && float.IsFinite(chargeRateValue)) // Ratbite: add float finite check
             _pred!.SendMessage(new BatterySetChargeRateMessage(chargeRateValue));
 
-        if (_dischargeRateCoalescer.CheckIsModified(out var dischargeRateValue))
+        if (_dischargeRateCoalescer.CheckIsModified(out var dischargeRateValue) && float.IsFinite(dischargeRateValue)) // Ratbite: add float finite check
             _pred!.SendMessage(new BatterySetDischargeRateMessage(dischargeRateValue));
     }
 

--- a/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
+++ b/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
@@ -1,4 +1,6 @@
 ﻿using Content.Server.Power.Components;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Content.Shared.Power;
 using Robust.Server.GameObjects;
 
@@ -20,6 +22,7 @@ namespace Content.Server.Power.EntitySystems;
 public sealed class BatteryInterfaceSystem : EntitySystem
 {
     [Dependency] private readonly UserInterfaceSystem _uiSystem = null!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     public override void Initialize()
     {
@@ -53,16 +56,24 @@ public sealed class BatteryInterfaceSystem : EntitySystem
 
     private void HandleSetChargeRate(Entity<BatteryInterfaceComponent> ent, ref BatterySetChargeRateMessage args)
     {
-        if (!float.IsFinite(args.Rate)) return; // Ratbite: check against malicious messages
+        if (!IsFiniteValueOrLog(args.Rate, args.Actor, args.Entity)) return; // Ratbite: check against malicious messages
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.MaxChargeRate = Math.Clamp(args.Rate, ent.Comp.MinChargeRate, ent.Comp.MaxChargeRate);
     }
 
     private void HandleSetDischargeRate(Entity<BatteryInterfaceComponent> ent, ref BatterySetDischargeRateMessage args)
     {
-        if (!float.IsFinite(args.Rate)) return; // Ratbite: check against malicious messages
+        if (!IsFiniteValueOrLog(args.Rate, args.Actor, args.Entity)) return; // Ratbite: check against malicious messages
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.MaxSupply = Math.Clamp(args.Rate, ent.Comp.MinSupply, ent.Comp.MaxSupply);
+    }
+
+    // Ratbite
+    private bool IsFiniteValueOrLog(float value, EntityUid user, NetEntity battery)
+    {
+        if (float.IsFinite(value)) return true;
+        _adminLogger.Add(LogType.Action, LogImpact.Extreme, $"{ToPrettyString(user):player} sent a NaN input to {ToPrettyString(battery)}! It's very likely that they are using a modified client.");
+        return false;
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
+++ b/Content.Server/Power/EntitySystems/BatteryInterfaceSystem.cs
@@ -53,12 +53,14 @@ public sealed class BatteryInterfaceSystem : EntitySystem
 
     private void HandleSetChargeRate(Entity<BatteryInterfaceComponent> ent, ref BatterySetChargeRateMessage args)
     {
+        if (!float.IsFinite(args.Rate)) return; // Ratbite: check against malicious messages
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.MaxChargeRate = Math.Clamp(args.Rate, ent.Comp.MinChargeRate, ent.Comp.MaxChargeRate);
     }
 
     private void HandleSetDischargeRate(Entity<BatteryInterfaceComponent> ent, ref BatterySetDischargeRateMessage args)
     {
+        if (!float.IsFinite(args.Rate)) return; // Ratbite: check against malicious messages
         var netBattery = Comp<PowerNetworkBatteryComponent>(ent);
         netBattery.MaxSupply = Math.Clamp(args.Rate, ent.Comp.MinSupply, ent.Comp.MaxSupply);
     }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Malicious clients could send BatterySetChargeRateMessage and BatterySetDischargeRateMessage with their value set as NaN and make the power go NaN and bug the server. You can test this by modifying the client only with this patch:
```patch
diff --git a/Content.Client/Power/Battery/BatteryBoundUserInterface.cs b/Content.Client/Power/Battery/BatteryBoundUserInterface.cs
index 561fe90e40..2cdcf3b9d2 100644
--- a/Content.Client/Power/Battery/BatteryBoundUserInterface.cs
+++ b/Content.Client/Power/Battery/BatteryBoundUserInterface.cs
@@ -47,10 +47,10 @@ protected override void Open()
     void IBuiPreTickUpdate.PreTickUpdate()
     {
         if (_chargeRateCoalescer.CheckIsModified(out var chargeRateValue))
-            _pred!.SendMessage(new BatterySetChargeRateMessage(chargeRateValue));
+            _pred!.SendMessage(new BatterySetChargeRateMessage(float.NaN));
 
         if (_dischargeRateCoalescer.CheckIsModified(out var dischargeRateValue))
-            _pred!.SendMessage(new BatterySetDischargeRateMessage(dischargeRateValue));
+            _pred!.SendMessage(new BatterySetDischargeRateMessage(float.NaN));
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)
```
And touch any SMEs/substation.

Note that this is one source of the NaN bug and there could be other similar ones.

## Why / Balance
Bug fix 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: NaN bug
