### PR TITLE
removed autocalling shuttle slop

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -107,20 +107,21 @@ namespace Content.Server.RoundEnd
         public TimeSpan? ExpectedShuttleLength => ExpectedCountdownEnd - LastCountdownStart;
         public TimeSpan? ShuttleTimeLeft => ExpectedCountdownEnd - _gameTiming.CurTime;
 
-        public TimeSpan AutoCallStartTime;
+        // public TimeSpan AutoCallStartTime;  // Ratbite - removed autocall
         private bool _autoCalledBefore = false;
 
         public override void Initialize()
         {
             base.Initialize();
             SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => Reset());
-            SetAutoCallTime();
+            // SetAutoCallTime(); // Ratbite - removed autocall
         }
 
-        private void SetAutoCallTime()
-        {
-            AutoCallStartTime = _gameTiming.CurTime;
-        }
+// Ratbite - removed autocall
+//        private void SetAutoCallTime()
+//        {
+//            AutoCallStartTime = _gameTiming.CurTime;
+//        }
 
         private void Reset()
         {
@@ -138,7 +139,7 @@ namespace Content.Server.RoundEnd
 
             LastCountdownStart = null;
             ExpectedCountdownEnd = null;
-            SetAutoCallTime();
+            // SetAutoCallTime(); // Ratbite - removed autocall
             _autoCalledBefore = false;
             RaiseLocalEvent(RoundEndSystemChangedEvent.Default);
         }
@@ -399,23 +400,25 @@ namespace Content.Server.RoundEnd
             }, _cooldownTokenSource.Token);
         }
 
-        public override void Update(float frameTime)
-        {
-            // Check if we should auto-call.
-            int mins = _autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
-                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
-            if (mins != 0 && _gameTiming.CurTime - AutoCallStartTime > TimeSpan.FromMinutes(mins))
-            {
-                if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
-                {
-                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
-                    _autoCalledBefore = true;
-                }
-
-                // Always reset auto-call in case of a recall.
-                SetAutoCallTime();
-            }
-        }
+// Ratbite - yeah bevv lets make rounds last 3 hours while automatically calling evac 1.5h in, slop
+//
+//        public override void Update(float frameTime)
+//        {
+//            // Check if we should auto-call.
+//            int mins = _autoCalledBefore ? _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallExtensionTime)
+//                                        : _cfg.GetCVar(CCVars.EmergencyShuttleAutoCallTime);
+//            if (mins != 0 && _gameTiming.CurTime - AutoCallStartTime > TimeSpan.FromMinutes(mins))
+//            {
+//                if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
+//                {
+//                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+//                    _autoCalledBefore = true;
+//                }
+//
+//                // Always reset auto-call in case of a recall.
+//                SetAutoCallTime();
+//            }
+//        }
     }
 
     public sealed class RoundEndSystemChangedEvent : EntityEventArgs


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
removed shuttle autocall
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
slop slop slop sahur, command should get off their lazy and incompetent asses to call it themselves if they want
also autocall kind of conflicts with bevv's vision of 3h rounds (genuinely unsure how to make it call it less often tho :joel:) (and ignoring the fact that in the current state 6+ month old goob content is absolutely not fitting for consistent 3 hour LRP rounds; it just MIGHT be okay for MRP but.. have you seen ratbite like at all :wilted_flower:)
## Technical details
<!-- Summary of code changes for easier review. -->
commented out autocall shit
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed shuttle autocall, better call it yourself now you lazy ass command!
