### PR TITLE
THE BETTY IS MADE BY SATAN

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/security.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Weapons/Melee/security.yml
@@ -157,7 +157,7 @@
       attackRate: 0.8
       damage:
         types:
-          Slash: 18
+          Slash: 14
       soundHit:
         path: /Audio/Weapons/bladeslice.ogg
     - type: ItemSwitch
@@ -180,7 +180,7 @@
               attackRate: 0.8
               damage:
                 types:
-                  Slash: 18
+                  Slash: 14
               soundHit:
                 path: /Audio/Weapons/bladeslice.ogg
           soundStateActivate:
@@ -197,16 +197,15 @@
               mustBeEquippedToUse: true # This thing shouldn't be able to attack at all but setting attackRate to 0 breaks stuff
               damage:
                 types:
-                  Blunt: 30
+                  Blunt: 20
               soundHit:
                 collection: TrayHit
             - type: MeleeThrowOnHit
               throwWhileOnDelay: true
               distance: 3
-            - type: KnockdownOnHit
             - type: MultiHandedItem
             - type: StaminaDamageOnHit
-              damage: 75
+              damage: 15
             - type: Item
               size: Ginormous
               sprite: _Goobstation/Objects/Weapons/Melee/betty.rsi


### PR DESCRIPTION
> im Not Happy

## About the PR
betty doesnt knockdown   betty does Less Stamina Damage Because why the hell Does it Do That  also does only 20 blunt on activated and 15 slash on deactivateed

## Why / Balance
the fact this thing does 75 stamina damage and knocks you down on hit is insane... it knocks you down so its insanely easy to get shoved about twice to fully get stam crit, does 30 blunt making it easier to kill you after stam critting you Come On Dude

## Technical details
removal of the knockdownonhit component on the betty and just some value changes,,,, i already said that in the first question

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: chrisyeaap
- tweak: Changed Betty's damage values and removed the knockdown on hit.
