### PR TITLE
Don't allow people with loyalty training to become antagonist

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -111,6 +111,7 @@ using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
 using Content.Server.Shuttles.Components;
 using Content.Server.Station.Events;
+using Content.Shared._BRatbite.Traits;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Antag;
 using Content.Shared.Clothing;
@@ -722,6 +723,9 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
 
         if (!def.AllowNonHumans && !HasComp<HumanoidAppearanceComponent>(entity))
             return false;
+
+        // Ratbite
+        if (HasComp<LoyaltyTrainingComponent>(entity)) return false;
 
         if (def.Whitelist != null)
         {

--- a/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
+++ b/Resources/Locale/en-US/_BRatbite/traits/traits.ftl
@@ -13,7 +13,7 @@ trait-sneak-desc = You feel more sneaky.
 
 trait-loyalty-training-name = NanoTrasen Loyalty Training
 trait-loyalty-training-desc =
-    You start with a mindshield implant. Normal mindshield rules apply.
+    You received extensive loyalty training, start with a mindshield and cannot be an antagonist. Normal mindshield rules apply.
 
 trait-pct-training-name = PCT Training
 trait-pct-training-desc =

--- a/Resources/Prototypes/_BRatbite/Traits/traits.yml
+++ b/Resources/Prototypes/_BRatbite/Traits/traits.yml
@@ -55,7 +55,7 @@
   name: trait-loyalty-training-name
   description: trait-loyalty-training-desc
   category: Mental
-  cost: -6
+  cost: -8
   components:
   - type: LoyaltyTraining
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Players who have the Loyalty training trait will not be able to become an antagonist. Because of this, the trait was buffed to give 8 points instead of 6

## Why / Balance
The trait mentioned loyalty training, but no actual loyalty was given

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Don't allow people with loyalty training to become antagonist
