### PR TITLE
Sanitarium fixes

### DIFF
--- a/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
@@ -39,6 +39,8 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Goobstation.Maths.FixedPoint;
+using Content.Shared._BRatbite.Chemistry;
+using Robust.Shared.Timing;
 
 namespace Content.Server._BRatbite.PermaBrig;
 
@@ -72,8 +74,8 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
     private readonly ProtoId<ReagentPrototype> _ketamine = "Ketamine";
-    // This is the equivalent of 10 minutes of sedation
-    private readonly FixedPoint2 _amountToInject = 2f;
+    private static readonly TimeSpan _sedationDuration = TimeSpan.FromMinutes(10);
+    private static readonly FixedPoint2 _amountToInject = _sedationDuration.TotalMinutes / 5f;
 
     public HashSet<ICommonSession> PermaIndividuals = new();
     public Dictionary<ICommonSession, (TimeSpan, TimeSpan)> PermaIndividualJoinedTime = new();
@@ -508,7 +510,18 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         var cuffs = _ent.SpawnEntity("ClothingOuterStraightjacket", Transform(prisoner).Coordinates);
         var cuffableComp = EnsureComp<CuffableComponent>(prisoner);
         _cuffableSystem.TryAddNewCuffs(prisoner, prisoner, cuffs, cuffableComp);
-        if (!TryComp<BloodstreamComponent>(prisoner, out var bloodstream)) return;
+
+        if (!TryComp<BloodstreamComponent>(prisoner, out var bloodstream))
+        {
+            // If the target deoesn't have a bloodstream, then add it as a computer virus
+            EnsureComp<KetamineVirusComponent>(prisoner);
+            Timer.Spawn(_sedationDuration, () =>
+            {
+                if (TerminatingOrDeleted(prisoner)) return;
+                RemComp<KetamineVirusComponent>(prisoner);
+            });
+            return;
+        }
         if (!_solutionContainerSystem.ResolveSolution(prisoner, bloodstream.BloodSolutionName, ref bloodstream.BloodSolution))
             return;
 

--- a/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
+++ b/Content.Server/_BRatbite/PermaBrig/PermaBrigSystem.cs
@@ -6,7 +6,6 @@ using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Spawners.Components;
 using Content.Server.Station.Systems;
 using Content.Server.StationRecords.Systems;
-using Content.Shared.Access;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared._Shitmed.Body.Organ;
@@ -93,7 +92,6 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
 
         SubscribeLocalEvent<RulePlayerSpawningEvent>(OnPlayerSpawning);
         SubscribeLocalEvent<PlayerBeforeSpawnEvent>(OnPlayerBeforeSpawning);
-        //SubscribeLocalEvent<RoundEndMessageEvent>(OnRoundEnd); Auto decreasing of
 
         _sawmill = Logger.GetSawmill("server_permabrig");
     }
@@ -440,12 +438,6 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         DebugTools.AssertNotNull(mobMaybe);
         var mob = mobMaybe!.Value;
 
-        // Inpatients should always receive a straightjacket, regardless of spawn path.
-        if (inpatient)
-        {
-            CuffAndInjectWithKetamine(mob);
-        }
-
         var brigTime = _permaBrigManager.GetBrigTime(player.UserId);
         var expireTime = TimeSpan.FromMinutes(brigTime) + Timing.CurTime;
         if (_inventory.TryGetSlotEntity(mob, "id", out var idUid))
@@ -502,6 +494,13 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
         _stationRecords.OnPlayerSpawn(aev);
         _trait.ApplyTraits(mob, character);
         _cryoSicknessSystem.ApplyComponent(mob);
+
+        // Inpatients should always receive a straightjacket, regardless of spawn path.
+        // We need to do it after everything else, to prevent people taking traits and bypass this
+        if (inpatient)
+        {
+            CuffAndInjectWithKetamine(mob);
+        }
     }
 
     private void CuffAndInjectWithKetamine(EntityUid prisoner)
@@ -515,9 +514,4 @@ public sealed class PermaBrigSystem : GameRuleSystem<PermaBrigComponent>
 
         _solutionContainerSystem.TryAddReagent(bloodstream.BloodSolution.Value, new ReagentId(_ketamine, null), _amountToInject, out _);
     }
-
-    // private void OnRoundEnd(RoundEndMessageEvent ev) Auto decrease of perma sentence not yet implemented
-    // {
-    //
-    // }
 }

--- a/Content.Shared/_BRatbite/Chemistry/KetamineSedationSystem.cs
+++ b/Content.Shared/_BRatbite/Chemistry/KetamineSedationSystem.cs
@@ -25,6 +25,10 @@ public sealed class KetamineSedationSystem : EntitySystem
 
     private bool HasActiveKetamine(EntityUid uid)
     {
+        if (HasComp<KetamineVirusComponent>(uid))
+        {
+            return true;
+        }
         var charcoalAmount = _solutions.GetTotalPrototypeQuantity(uid, "Charcoal").Float();
         if (charcoalAmount >= 10f)
             return false;

--- a/Content.Shared/_BRatbite/Chemistry/KetamineVirusComponent.cs
+++ b/Content.Shared/_BRatbite/Chemistry/KetamineVirusComponent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.Chemistry;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class KetamineVirusComponent : Component;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fix bug where, if you took prybar hands as a sanitarium patient, you would spawn unrestrained.
Give IPCs a computer virus roundstart equivalent to the 10 minutes of ketamine injection that other species get

## Why / Balance
Bug fixes

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="1088" height="286" alt="image" src="https://github.com/user-attachments/assets/d99115cf-206d-4130-8381-3cbbb74351e2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: IPCs not being sedated, and people with prybar arms being unrestrained
