### PR TITLE
Mindshield armors

### DIFF
--- a/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
+++ b/Content.Shared/Movement/Systems/MovementSpeedModifierSystem.cs
@@ -110,7 +110,7 @@ namespace Content.Shared.Movement.Systems
                 isImmune = true;
             // </Goobstation Change>
 
-            var ev = new RefreshMovementSpeedModifiersEvent(isImmune);
+            var ev = new RefreshMovementSpeedModifiersEvent(uid, isImmune);
             RaiseLocalEvent(uid, ev);
 
             if (MathHelper.CloseTo(ev.WalkSpeedModifier, move.WalkSpeedModifier) &&
@@ -181,6 +181,8 @@ namespace Content.Shared.Movement.Systems
     /// </summary>
     public sealed class RefreshMovementSpeedModifiersEvent : EntityEventArgs, IInventoryRelayEvent
     {
+        // ratbite
+        public EntityUid User;
         public SlotFlags TargetSlots { get; } = ~SlotFlags.POCKET;
 
         public float WalkSpeedModifier { get; private set; } = 1.0f;
@@ -203,9 +205,10 @@ namespace Content.Shared.Movement.Systems
             SprintSpeedModifier *= sprint;
         }
 
-        public RefreshMovementSpeedModifiersEvent(bool isImmune = false)
+        public RefreshMovementSpeedModifiersEvent(EntityUid user, bool isImmune = false)
         {
             _isImmune = isImmune;
+            User = user;
         }
         // </Goobstation Change>
 

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.Event.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.Event.cs
@@ -1,0 +1,33 @@
+using Content.Shared._BRatbite.Revolutionary;
+using Content.Shared.Mindshield.Components;
+
+namespace Content.Shared.Revolutionary;
+
+public abstract partial class SharedRevolutionarySystem : EntitySystem
+{
+    private void SubscribeMindshieldEvents()
+    {
+        SubscribeLocalEvent<MindShieldComponent, ComponentShutdown>(OnMindshieldRemove);
+        SubscribeLocalEvent<FakeMindShieldComponent, MapInitEvent>(OnFakeMindshieldImplanted);
+        SubscribeLocalEvent<FakeMindShieldComponent, ComponentShutdown>(OnFakeMindshieldRemove);
+        SubscribeLocalEvent<MindShieldComponent, MapInitEvent>(MindShieldImplanted);
+    }
+    private void OnMindshieldRemove(Entity<MindShieldComponent> ent, ref ComponentShutdown args)
+    {
+        var ev = new MindShieldChangedEvent(false, false);
+        RaiseLocalEvent(ent, ref ev);
+    }
+
+    private void OnFakeMindshieldRemove(Entity<FakeMindShieldComponent> ent, ref ComponentShutdown args)
+    {
+        var ev = new MindShieldChangedEvent(false, true);
+        RaiseLocalEvent(ent, ref ev);
+    }
+
+    private void OnFakeMindshieldImplanted(Entity<FakeMindShieldComponent> ent, ref MapInitEvent args)
+    {
+        var ev = new MindShieldChangedEvent(true, true);
+        RaiseLocalEvent(ent, ref ev);
+    }
+
+}

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -8,10 +8,11 @@ using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 using Content.Shared.Antag;
+using Content.Shared._BRatbite.Revolutionary;
 
 namespace Content.Shared.Revolutionary;
 
-public abstract class SharedRevolutionarySystem : EntitySystem
+public abstract partial class SharedRevolutionarySystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
@@ -20,7 +21,6 @@ public abstract class SharedRevolutionarySystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MindShieldComponent, MapInitEvent>(MindShieldImplanted);
         SubscribeLocalEvent<RevolutionaryComponent, ComponentGetStateAttemptEvent>(OnRevCompGetStateAttempt);
         SubscribeLocalEvent<HeadRevolutionaryComponent, ComponentGetStateAttemptEvent>(OnRevCompGetStateAttempt);
 
@@ -28,6 +28,8 @@ public abstract class SharedRevolutionarySystem : EntitySystem
         SubscribeLocalEvent<HeadRevolutionaryComponent, ComponentStartup>(OnRevolutionaryComponentStartup); // Goob Station - Revolutionary Language
 
         SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(OnRevolutionaryComponentStartup);
+        // Ratbite
+        SubscribeMindshieldEvents();
     }
 
     /// <summary>
@@ -35,6 +37,9 @@ public abstract class SharedRevolutionarySystem : EntitySystem
     /// </summary>
     private void MindShieldImplanted(EntityUid uid, MindShieldComponent comp, MapInitEvent init)
     {
+        // Ratbite
+        var ev = new MindShieldChangedEvent(true, false);
+        RaiseLocalEvent(uid, ref ev);
         if (HasComp<HeadRevolutionaryComponent>(uid))
         {
             comp.Broken = true; // Goobstation - Broken mindshield implant instead of break it

--- a/Content.Shared/_BRatbite/Alerts/ShowMindShieldAlertSystem.cs
+++ b/Content.Shared/_BRatbite/Alerts/ShowMindShieldAlertSystem.cs
@@ -2,28 +2,28 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+using Content.Shared._BRatbite.Revolutionary;
 using Content.Shared.Alert;
 using Content.Shared.Mindshield.Components;
 
 namespace Content.Shared._BRatbite.Alerts;
 
-public sealed class ShowMindShieldAlertSystem : EntitySystem {
+public sealed class ShowMindShieldAlertSystem : EntitySystem
+{
     [Dependency] private readonly AlertsSystem _alerts = default!;
-	public override void Initialize()
-	{
-	    base.Initialize();
+    public override void Initialize()
+    {
+        base.Initialize();
 
-	    SubscribeLocalEvent<MindShieldComponent, ComponentStartup>(OnMindShieldStartup);
-	    SubscribeLocalEvent<MindShieldComponent, ComponentShutdown>(OnMindShieldShutdown);
-	}
+        SubscribeLocalEvent<MindShieldComponent, MindShieldChangedEvent>(OnMindShieldStartup);
+    }
 
-	private void OnMindShieldStartup(Entity<MindShieldComponent> ent, ref ComponentStartup args)
-	{
-	    _alerts.ShowAlert(ent.Owner, ent.Comp.MindShieldAlert);
-	}
-
-	private void OnMindShieldShutdown(Entity<MindShieldComponent> ent, ref ComponentShutdown args)
-	{
-	    _alerts.ClearAlert(ent.Owner, ent.Comp.MindShieldAlert);
-	}
+    private void OnMindShieldStartup(Entity<MindShieldComponent> ent, ref MindShieldChangedEvent args)
+    {
+        if (args.Fake) return;
+        if (args.Active)
+            _alerts.ShowAlert(ent.Owner, ent.Comp.MindShieldAlert);
+        else
+            _alerts.ClearAlert(ent.Owner, ent.Comp.MindShieldAlert);
+    }
 }

--- a/Content.Shared/_BRatbite/Armor/MindshieldArmorComponent.cs
+++ b/Content.Shared/_BRatbite/Armor/MindshieldArmorComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._BRatbite.Armor;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class MindshieldArmorComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float Slowdown = 0.75f;
+}

--- a/Content.Shared/_BRatbite/Armor/MindshieldArmorSystem.cs
+++ b/Content.Shared/_BRatbite/Armor/MindshieldArmorSystem.cs
@@ -1,0 +1,47 @@
+using Content.Shared._BRatbite.Revolutionary;
+using Content.Shared.Armor;
+using Content.Shared.Body.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Inventory;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Systems;
+
+namespace Content.Shared._BRatbite.Armor;
+
+public sealed partial class MindshieldArmorSystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+    [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifierSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<MindshieldArmorComponent, InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent>>(OnRefreshMovementSpeed);
+        SubscribeLocalEvent<MindshieldArmorComponent, ArmorExamineEvent>(OnArmorExamine);
+        SubscribeLocalEvent<MovementSpeedModifierComponent, MindShieldChangedEvent>(OnMindshieldChanged);
+    }
+
+    private void OnMindshieldChanged(Entity<MovementSpeedModifierComponent> ent, ref MindShieldChangedEvent args)
+    {
+        if (TerminatingOrDeleted(ent)) return;
+        _movementSpeedModifierSystem.RefreshMovementSpeedModifiers(ent);
+    }
+
+    private void OnRefreshMovementSpeed(Entity<MindshieldArmorComponent> ent, ref InventoryRelayedEvent<RefreshMovementSpeedModifiersEvent> args)
+    {
+        if (HasComp<MindShieldComponent>(args.Args.User) || HasComp<FakeMindShieldComponent>(args.Args.User)) return;
+        args.Args.ModifySpeed(ent.Comp.Slowdown);
+    }
+
+    private void OnArmorExamine(Entity<MindshieldArmorComponent> ent, ref ArmorExamineEvent args)
+    {
+        var msg = args.Msg;
+        if (msg is null) return; // Sometimes msg was null during testing, I
+                         // think it was because I was hot reloading
+                         // the yaml, but I'm going to add this just
+                         // in case
+        msg.PushNewline();
+        msg.AddMarkupOrThrow(Loc.GetString("mindshield-armor-slowdown", [("value", MathF.Round((1f - ent.Comp.Slowdown) * 100f))]));
+    }
+}

--- a/Content.Shared/_BRatbite/Revolutionary/MindShieldChangedEvent.cs
+++ b/Content.Shared/_BRatbite/Revolutionary/MindShieldChangedEvent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._BRatbite.Revolutionary;
+
+[ByRefEvent]
+public record struct MindShieldChangedEvent(bool Active, bool Fake);

--- a/Resources/Locale/en-US/_BRatbite/armor/armor.ftl
+++ b/Resources/Locale/en-US/_BRatbite/armor/armor.ftl
@@ -1,0 +1,1 @@
+mindshield-armor-slowdown=Slows down the wearer by [color=lightblue]{$value}%[/color] if they don't have a [color=cyan]mindshield[/color]

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -43,6 +43,7 @@
         Slash: 0.7
         Piercing: 0.7
         Heat: 0.8
+  - type: MindshieldArmor
   - type: Tag
     tags:
     - WhitelistChameleon
@@ -113,7 +114,8 @@
     sprite: Clothing/Head/Helmets/swat.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/swat.rsi
-  #- type: Armor # Goob Start - ClothingHeadHelmetSwatBase makes this obsolete
+  - type: MindshieldArmor
+  #- type: Armor # Goob Start - ClothingHeadHelmetSwatBase makes this obsolete 
   #  coverage:
   #  - Head
   #  traumaDeductions:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -32,11 +32,11 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.55
-        Slash: 0.55
-        Piercing: 0.55
-        Heat: 0.7
-    # Goob end
+        Blunt: 0.50  #Ratbite
+        Slash: 0.50 #Ratbite
+        Piercing: 0.4 #Ratbite
+        Heat: 0.7 #Ratbite
+  - type: MindshieldArmor # Ratbite
   - type: ExplosionResistance
     damageCoefficient: 0.90
   - type: ModifyDelayedKnockdown # Goobstation
@@ -91,11 +91,11 @@
       NerveDamage: 0
     modifiers:
       coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.3
-        Heat: 0.8
-    # Goob end
+        Blunt: 0.8 # Ratbite - Resists are balanced by the fact that if you get melee'd
+        Slash: 0.8 # at ALL in a bullet vest you WILL just fold.
+        Piercing: 0.4 # I read it yo.
+        Heat: 0.6
+  - type: MindshieldArmor # Ratbite
   - type: ExplosionResistance
     damageCoefficient: 0.80
 
@@ -160,6 +160,7 @@
     sprintModifier: 1.0
   - type: HeldSpeedModifier
   - type: GroupExamine
+  - type: MindshieldArmor
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseCommandContraband] # Goobstation?

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -101,6 +101,7 @@
         Piercing: 0.40 # Ratbite balance, cannot believe I forgot this lmfao I've been so cooked for so long. -bevv
         Heat: 0.55
         Caustic: 0.6
+  - type: MindshieldArmor # Ratbite
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation
@@ -132,6 +133,7 @@
         Piercing: 0.65
         Heat: 0.55
         Caustic: 0.8
+  - type: MindshieldArmor # Ratbite
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: ModifyDelayedKnockdown # Goobstation

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -455,6 +455,7 @@
         Piercing: 0.4 #Ratbite
         Heat: 0.7 #Ratbite
         Caustic: 0.7
+  - type: MindshieldArmor # Ratbite
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -494,6 +495,7 @@
         Heat: 0.85
         Radiation: 0.4
         Caustic: 0.4
+  - type: MindshieldArmor # Ratbite
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -538,6 +540,7 @@
         Piercing: 0.4 #Ratbite
         Heat: 0.8
         Caustic: 0.7
+  - type: MindshieldArmor # Ratbite
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -585,6 +588,7 @@
         Heat: 0.6 #Goob - Modsuit Rebalance end
         Radiation: 0.15
         Caustic: 0.6
+  - type: MindshieldArmor # Ratbite
   - type: ClothingSpeedModifier
     walkModifier: 0.9 #Goob - Modsuit Rebalance
     sprintModifier: 0.9 #Goob - Modsuit Rebalance
@@ -628,6 +632,7 @@
         Heat: 0.4
         Radiation: 0.0
         Caustic: 0.7
+  - type: MindshieldArmor
   - type: ClothingSpeedModifier
     walkModifier: 0.80 #Ratbite
     sprintModifier: 0.9 #Ratbite
@@ -1353,6 +1358,8 @@
         Cellular: 0.3 #Ratbite
         Radiation: 0.3 #Ratbite
         Caustic: 0.3 #Ratbite
+  - type: MindshieldArmor # Ratbite
+    slowdown: 0
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/_BRatbite/Entities/Clothing/OuterClothing/Coats/RSOArmors.yml
+++ b/Resources/Prototypes/_BRatbite/Entities/Clothing/OuterClothing/Coats/RSOArmors.yml
@@ -18,3 +18,4 @@
         Piercing: 0.35
         Heat: 0.35
         Caustic: 0.6
+  - type: MindshieldArmor

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/modsuit.yml
@@ -159,6 +159,7 @@
         Piercing: 0.55
         Heat: 0.55
         Radiation: 0.6
+  - type: MindshieldArmor
   - type: ComponentToggler
     components:
     - type: PressureProtection
@@ -239,6 +240,7 @@
         Caustic: 0.5
         Radiation: 0.4
         #ratbite lil more protection, lil less speed
+  - type: MindshieldArmor
   - type: ComponentToggler
     components:
     - type: PressureProtection
@@ -637,6 +639,7 @@
         Radiation: 0.1
         Caustic: 0.5
         #ratbite its fucking CAPTAIN man
+  - type: MindshieldArmor
   - type: ComponentToggler
     components:
     - type: PressureProtection


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Add MindshieldArmor component. Armors with this component will slow down users that do not have a mindshield (or a fake one, even set to not show in the icon).
The lore reason is:
> command/security armor needs a mindshield to properly interface with the user, otherwise its internal motors do not assist with movement and it is sluggish at best. a fake mindshield tricks it.

## Why / Balance

Ratbite buffed a lot of armors as protection against self antags, however it is still very easy for anyone to steal security gear (You don't even have to do any combat, you can easily steal a locker or wait for a security member to show up unconscious to med). This has the opposite effect, where shitters will openly wear armor and be a nuisance to everyone because.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="416" height="460" alt="image" src="https://github.com/user-attachments/assets/e7e2f1f5-ebbd-4176-94df-38164513bb13" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mindshield armor
