### PR TITLE
Use original station for station AI vision instead of current grid

### DIFF
--- a/Content.Client/Silicons/StationAi/StationAiOverlay.cs
+++ b/Content.Client/Silicons/StationAi/StationAiOverlay.cs
@@ -81,6 +81,7 @@ public sealed class StationAiOverlay : Overlay
         var worldBounds = args.WorldBounds;
 
         var playerEnt = _player.LocalEntity;
+        var originalGridUid = _entManager.GetComponentOrNull<StationAiHeldComponent>(playerEnt)?.OriginalStation; // Ratbite
 
         // Shitmed - Starlight Abductors Change Start
         if (_entManager.TryGetComponent(playerEnt, out StationAiOverlayComponent? stationAiOverlay)
@@ -90,7 +91,7 @@ public sealed class StationAiOverlay : Overlay
         // Shitmed Change End
 
         _entManager.TryGetComponent(playerEnt, out TransformComponent? playerXform);
-        var gridUid = playerXform?.GridUid ?? EntityUid.Invalid;
+        var gridUid = originalGridUid ?? EntityUid.Invalid; // Ratbite: Change to original station uid
         _entManager.TryGetComponent(gridUid, out MapGridComponent? grid);
         _entManager.TryGetComponent(gridUid, out BroadphaseComponent? broadphase);
 

--- a/Content.Goobstation.Server/Silicon/AiCameraWarping/StationAiWarpSystem.cs
+++ b/Content.Goobstation.Server/Silicon/AiCameraWarping/StationAiWarpSystem.cs
@@ -33,7 +33,7 @@ public sealed class StationAiWarpSystem : SharedStationAiWarpSystem
         if (!_stationAiSystem.TryGetCore(ent.Owner, out var core))
             return;
 
-        var cameras = GetCameras(core.Owner);
+        var cameras = GetCameras(ent);
 
         var state = new CameraWarpBuiState(cameras);
         _userInterface.SetUiState(ent.Owner, CamWarpUiKey.Key, state);
@@ -43,26 +43,25 @@ public sealed class StationAiWarpSystem : SharedStationAiWarpSystem
     {
         if (args.Handled || !TryComp<ActorComponent>(ent.Owner, out var actor))
             return;
-        if (!_stationAiSystem.TryGetCore(ent.Owner, out var core))
-            return;
 
         args.Handled = true;
 
         _userInterface.TryToggleUi(ent.Owner, CamWarpUiKey.Key, actor.PlayerSession);
 
-        var cameras = GetCameras(core.Owner);
+        var cameras = GetCameras(ent);
 
         var state = new CameraWarpBuiState(cameras);
         _userInterface.SetUiState(ent.Owner, CamWarpUiKey.Key, state);
     }
 
-    private List<CameraWarpData> GetCameras(EntityUid coreUid)
+    private List<CameraWarpData> GetCameras(Entity<StationAiHeldComponent> ent)
     {
         List<CameraWarpData> cameras = new();
 
         var query = EntityManager.EntityQueryEnumerator<SurveillanceCameraComponent>();
 
-        var aiGrid = _xformSystem.GetGrid(coreUid);
+        // Ratbite
+        var aiGrid = ent.Comp.OriginalStation;
 
         while (query.MoveNext(out var queryUid, out var comp))
         {
@@ -98,7 +97,7 @@ public sealed class StationAiWarpSystem : SharedStationAiWarpSystem
             return;
 
         // The AI shouldn't be able to jump to cams on other stations/shuttles
-        if (_xformSystem.GetGrid(core.Owner) != _xformSystem.GetGrid(target))
+        if (ent.Comp.OriginalStation != _xformSystem.GetGrid(target))
             return;
 
         _xformSystem.SetWorldPosition(core.Comp.RemoteEntity.Value, _xformSystem.GetWorldPosition(target));

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -192,6 +192,11 @@ public sealed class HolopadSystem : SharedHolopadSystem
         // AI broadcasting
         if (TryComp<StationAiHeldComponent>(args.Actor, out var stationAiHeld))
         {
+            if (Transform(args.Actor).GridUid != Transform(source).GridUid)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("holopad-ai-is-unable-to-activate-projector"), source, args.Actor);
+                return;
+            }
             // Link the AI to the holopad they are broadcasting from
             LinkHolopadToUser(source, args.Actor);
 

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -124,6 +124,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         SubscribeLocalEvent<StationAiWhitelistComponent, BoundUserInterfaceCheckRangeEvent>(OnAiBuiCheck);
 
+
+        SubscribeLocalEvent<StationAiHeldComponent, MapInitEvent>(OnAiHeldInit);
         SubscribeLocalEvent<StationAiOverlayComponent, AccessibleOverrideEvent>(OnAiAccessible);
         SubscribeLocalEvent<StationAiOverlayComponent, InRangeOverrideEvent>(OnAiInRange);
         SubscribeLocalEvent<StationAiOverlayComponent, MenuVisibilityEvent>(OnAiMenu);
@@ -204,7 +206,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiBuiCheck(Entity<StationAiWhitelistComponent> ent, ref BoundUserInterfaceCheckRangeEvent args)
     {
-        if (!HasComp<StationAiHeldComponent>(args.Actor))
+        if (!TryComp<StationAiHeldComponent>(args.Actor, out var stationAiHeld))
             return;
 
         args.Result = BoundUserInterfaceRangeResult.Fail;
@@ -213,7 +215,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         var targetXform = Transform(args.Target);
 
         // No cross-grid
-        if (targetXform.GridUid != args.Actor.Comp.GridUid)
+        // Ratbite: use original station
+        if (targetXform.GridUid != stationAiHeld.OriginalStation)
         {
             return;
         }
@@ -236,6 +239,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiInRange(Entity<StationAiOverlayComponent> ent, ref InRangeOverrideEvent args)
     {
+        // Ratbite
+        if (!TryComp<StationAiHeldComponent>(ent, out var stationAiHeld)) return;
         args.Handled = true;
 
         // Shitmed - Starlight Abductors Change Start
@@ -247,7 +252,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         var targetXform = Transform(target);
 
         // No cross-grid
-        if (targetXform.GridUid != Transform(args.User).GridUid && !ent.Comp.AllowCrossGrid) // Shitmed Change
+        // Ratbite: use original station
+        if (targetXform.GridUid != stationAiHeld.OriginalStation && !ent.Comp.AllowCrossGrid) // Shitmed Change
         {
             return;
         }
@@ -619,6 +625,14 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         return _blocker.CanComplexInteract(entity.Owner);
     }
+
+    // Ratbite
+    private void OnAiHeldInit(Entity<StationAiHeldComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.OriginalStation = Transform(ent).GridUid;
+        Dirty(ent);
+    }
+
 }
 
 public sealed partial class JumpToCoreEvent : InstantActionEvent

--- a/Content.Shared/Silicons/StationAi/StationAiHeldComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiHeldComponent.cs
@@ -29,11 +29,15 @@ namespace Content.Shared.Silicons.StationAi;
 /// <summary>
 /// Indicates this entity is currently held inside of a station AI core.
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 // Corvax-Next-AiRemoteControl-Start
 public sealed partial class StationAiHeldComponent : Component
 {
     [DataField]
     public EntityUid? CurrentConnectedEntity;
+
+    // Ratbite
+    [DataField, AutoNetworkedField]
+    public EntityUid? OriginalStation = null;
 }
 // Corvax-Next-AiRemoteControl-End


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Use original station for station AI vision instead of station core grid.

## Why / Balance
The station AI core is already isolated from the rest of the station on many stations, this means that the AI is using some kind of wireless connection to the station, it doesn't make sense that just by physically disconnecting it, it can't control it anymore.
This also prevents shitters from sabotaging the AI with just an RCD

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="1129" height="769" alt="image" src="https://github.com/user-attachments/assets/c46bff66-2f78-47f6-8f45-109e8fe89df4" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The station AI will now only be able to control the station even if it changes grid
