### PR TITLE
Remove relayed death rattle ping

### DIFF
--- a/Content.Goobstation.Server/RelayedDeathrattle/RelayedDeathrattleSystem.cs
+++ b/Content.Goobstation.Server/RelayedDeathrattle/RelayedDeathrattleSystem.cs
@@ -18,7 +18,6 @@
 using Content.Server.Chat.Systems;
 using Content.Server.Medical.CrewMonitoring;
 using Content.Server.Pinpointer;
-using Content.Shared._BRatbite.TrackingHud;
 using Content.Shared.Chat;
 using Content.Shared.Mobs;
 using Robust.Server.GameObjects;
@@ -30,7 +29,6 @@ public sealed class RelayedDeathrattleSystem : EntitySystem
 {
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly SharedTrackingTargetSystem _trackingTargetSystem = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
     public override void Initialize()
@@ -53,14 +51,6 @@ public sealed class RelayedDeathrattleSystem : EntitySystem
             dead = true;
         else
             return;
-        // Ratbite start
-        var coordinates = _transform.GetMapCoordinates(Transform(uid));
-        _trackingTargetSystem.AddTargetToAllEntities(new TrackingTarget
-        {
-            TargetLocation = coordinates.Position,
-            MapId = coordinates.MapId,
-        }, deleteAfter: TimeSpan.FromSeconds(30));
-        // Ratbite end
         _chat.TrySendInGameICMessage(comp.Target.Value, Loc.GetString(dead ? comp.DeathMessage : comp.CritMessage, ("user", uid), ("position", posText)), InGameICChatType.Speak, hideChat: false);
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
When heads die, if they have been implanted by BSO, they send a pointer to all sec.
This is a mistake on my part, because I thought that system handled tracking implants and not BSO implants

## Why / Balance
Heads that die should not ping every sec officer

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Remove relayed death rattle ping
