### PR TITLE
Fixes stamina resistance being squared in effectiveness to disablers/batons/etc

### DIFF
--- a/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
+++ b/Content.Goobstation.Server/Changeling/ChangelingSystem.cs
@@ -308,7 +308,7 @@ public sealed partial class ChangelingSystem : SharedChangelingSystem
         if (comp.StrainedMusclesActive)
         {
             var stamina = EnsureComp<StaminaComponent>(uid);
-            _stamina.TakeStaminaDamage(uid, 7.5f, visual: false, immediate: false);
+            _stamina.TakeStaminaDamage(uid, 7.5f, visual: false, immediate: false, ignoreResist: true);
             if (stamina.StaminaDamage >= stamina.CritThreshold || _gravity.IsWeightless(uid))
                 ToggleStrainedMuscles(uid, comp);
         }

--- a/Content.Goobstation.Shared/Dash/DashActionSystem.cs
+++ b/Content.Goobstation.Shared/Dash/DashActionSystem.cs
@@ -50,7 +50,7 @@ public sealed class DashActionSystem : EntitySystem
         _throwing.TryThrow(args.Performer, vec, speed, animated: false);
 
         if (args.StaminaDrain != null)
-            _stamina.TakeStaminaDamage(args.Performer, args.StaminaDrain.Value, visual: false, immediate: false);
+            _stamina.TakeStaminaDamage(args.Performer, args.StaminaDrain.Value, visual: false, immediate: false, ignoreResist: true);
 
         if (args.Emote != null && TryComp<AnimatedEmotesComponent>(args.Performer, out var emotes))
         {

--- a/Content.Goobstation.Shared/Projectiles/ProjectileImmunitySystem.cs
+++ b/Content.Goobstation.Shared/Projectiles/ProjectileImmunitySystem.cs
@@ -96,7 +96,7 @@ public sealed class ProjectileImmunitySystem : EntitySystem
         args.Reflected = true;
 
         if (ent.Comp.StaminaCostPerDodge > 0)
-            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false);
+            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false, ignoreResist: true);
 
         if (ent.Comp.DodgeEffect != null)
             SpawnAttachedTo(ent.Comp.DodgeEffect.Value, new EntityCoordinates(ent, Vector2.Zero));
@@ -111,7 +111,7 @@ public sealed class ProjectileImmunitySystem : EntitySystem
             return;
 
         if (ent.Comp.StaminaCostPerDodge > 0)
-            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false);
+            _stamina.TakeStaminaDamage(ent, ent.Comp.StaminaCostPerDodge, logDamage: false, ignoreResist: true);
 
         if (ent.Comp.DodgeEffect != null)
             SpawnAttachedTo(ent.Comp.DodgeEffect.Value, new EntityCoordinates(ent, Vector2.Zero));

--- a/Content.Goobstation.Shared/Stunnable/OvertimeStaminaDamageSystem.cs
+++ b/Content.Goobstation.Shared/Stunnable/OvertimeStaminaDamageSystem.cs
@@ -51,7 +51,7 @@ public sealed partial class OvertimeStaminaDamageSystem : EntitySystem
     {
         var damage = ent.Comp.Amount / ent.Comp.Delta;
 
-        _stamina.TakeStaminaDamage(ent, damage, immediate: false, visual: false);
+        _stamina.TakeStaminaDamage(ent, damage, immediate: false, visual: false, ignoreResist: true); // Ignore resists, we calculated in resists already);
 
         ent.Comp.Damage -= damage;
 

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -271,7 +271,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         damage *= hitEvent.Value;
         overtime *= hitEvent.Value;
 
-        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound, // Goob: Ignore resists, we calculated this already.);
+        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound, ignoreResist: true); // Goob: Ignore resists, we calculated this already.
         TakeOvertimeStaminaDamage(target, overtime); // Goobstation
     }
 

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -226,7 +226,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
                 damageOvertime *= component.LightAttackOvertimeDamageMultiplier;
             }
 
-            TakeStaminaDamage(ent, damageImmediate / toHit.Count, comp, source: args.User, with: args.Weapon, sound: component.Sound, immediate: true);
+            TakeStaminaDamage(ent, damageImmediate / toHit.Count, comp, source: args.User, with: args.Weapon, sound: component.Sound, immediate: true, ignoreResist: true); // Goob: IgnoreResist: true, we already calculated resists
             TakeOvertimeStaminaDamage(ent, damageOvertime);
         }
     }
@@ -271,7 +271,7 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         damage *= hitEvent.Value;
         overtime *= hitEvent.Value;
 
-        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound);
+        TakeStaminaDamage(target, damage, source: uid, sound: component.Sound, // Goob: Ignore resists, we calculated this already.);
         TakeOvertimeStaminaDamage(target, overtime); // Goobstation
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Goob fucked up stamina code like 2 months ago from an upstream and never noticed or fixed it 

Tl;dr if you had 30% stam resist you'd have around 51% actual stam resist

if you had 80% stam resist would be 96% stam resist

this is cause it applies stamina resistance in the oncollide/onhit calculations and then again in "take stamina damage" calculation

https://github.com/Goob-Station/Goob-Station/pull/7034

Solution is to make it ignore resists when appropiate.

Also makes it ignore resists on some other sources of self-inflicted stamina damage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

literally breaks stamina combat entirely the second anyone has any amount of stamina resist

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed stamina resist being ^2 in effectiveness
