### PR TITLE
Remove opaque collision on items like closets when they are opened

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/artifact_equipment.yml
@@ -45,6 +45,7 @@
       sprite: Structures/Storage/Crates/artifact.rsi
       state: artifact_container_icon
     - type: EntityStorage
+      masksToRemove: 29 # Ratbite: Fix exploit
       capacity: 1
       whitelist:
         components:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -15,6 +15,7 @@
   - type: AccessReader
     access: [["Bar"]]
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
     closeSound:
       path: /Audio/Effects/woodenclosetclose.ogg
     openSound:

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -48,7 +48,7 @@
         - MachineLayer
   - type: EntityStorage
     # Goob start; allow changing collisionmasks to remove when opening containers
-    masksToRemove: 84
+    masksToRemove: 85 # Ratbite: fix exploit
     #Goob end
   - type: ContainerContainer
     containers:
@@ -273,6 +273,7 @@
         layer:
         - MachineLayer
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
   - type: ContainerContainer
     containers:
       entity_storage: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -32,6 +32,7 @@
       openOnMove: false
       airtight: false
       capacity: 5 #5 entity capacity to fit all of your friends (or teammates on your nuclear operation without reinforcements).
+      masksToRemove: 29 # Ratbite: Fix exploit
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -110,6 +111,7 @@
             - SlipLayer
           hard: false #It's a ghostly box, it can go through walls
     - type: EntityStorage
+      masksToRemove: 29 # Ratbite: Fix exploit
       isCollidableWhenOpen: false
       openOnMove: false
       airtight: false

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/cursed.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/cursed.yml
@@ -9,5 +9,6 @@
   components:
   - type: CursedEntityStorage
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
     closeSound:
       path: /Audio/Effects/teleport_arrival.ogg

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -41,6 +41,7 @@
         layer:
         - MachineLayer
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
   - type: PlaceableSurface
     isPlaceable: false # defaults to closed.
   - type: Damageable

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -196,6 +196,7 @@
             min: 3
             max: 5
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
     closeSound:
       path: /Audio/Effects/rustle1.ogg
     openSound:
@@ -376,6 +377,7 @@
   name: livestock crate
   components:
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
     airtight: false
   - type: Sprite
     sprite: Structures/Storage/Crates/livestock.rsi
@@ -474,6 +476,7 @@
   - type: Physics
     bodyType: Dynamic
   - type: EntityStorage
+    masksToRemove: 29 # Ratbite: Fix exploit
     capacity: 1
     airtight: false
   - type: Fixtures


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Remove opaque collision on items like closets when they are opened.
This fixes the exploit where people would use lockers and crates to bypass the turret AI.

## Why / Balance
Fix exploit that made turrets useless

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="301" height="498" alt="image" src="https://github.com/user-attachments/assets/2151127f-5844-4184-b904-40d13fadde2c" /> (Laser bullet goes through when it's opened)
<img width="530" height="201" alt="image" src="https://github.com/user-attachments/assets/dc95c285-a419-4bd1-8a7f-9eef6fd478fe" /> (Laser bullet gets absorbed when it's closed)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [ ] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Remove opaque collision on items like closets when they are opened
