### PR TITLE
Passenger/Zookeeper Loadout Tweaks

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -28,6 +28,12 @@
   equipment:
     mask: ClothingMaskGas
 
+# Ratbite pirate eyepatch
+- type: loadout
+  id: PirateEyepatch
+  equipment:
+    eyes: ClothingEyesEyepatch
+
 # Jumpsuits
 # Grey
 - type: loadout
@@ -104,6 +110,12 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitMilitaryTurtleneckMercenary
 
+# Ratbite pirate slops
+- type: loadout
+  id: PirateJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitPirate
+
 # Neck
 - type: loadout
   id: Mantle
@@ -173,6 +185,12 @@
   equipment:
     outerClothing: ClothingOuterWinterCoat
 
+# Ratbite pirate coat
+- type: loadout
+  id: PirateCoat
+  equipment:
+    outerClothing: ClothingOuterCoatPirate
+
 # Shoes
 - type: loadout
   id: BlackShoes
@@ -184,3 +202,9 @@
   equipment:
     shoes: ClothingShoesBootsWinter
 
+# Head
+# Ratbite pirate hat
+- type: loadout
+  id: PirateHat
+  equipment:
+    head: ClothingHeadHatPirate

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -92,6 +92,7 @@
   - GlassesJamjar
   - GlassesJensen
   - CheapSunglasses # Goobstation
+  - PirateEyepatch # ratbite
 
 - type: loadoutGroup
   id: Animals  # Goobstation
@@ -274,6 +275,10 @@
   - MercGreenJumpsuit
   - MercBlueJumpsuit
   - FreakPants
+  - ZookeeperJumpsuit
+  - PirateJumpsuit
+  - BoxerShortsWithTop
+  - BoxerShorts
 
 #ratbite end
   - RainbowJumpsuit
@@ -308,7 +313,10 @@
   minLimit: 0
   loadouts:
   - MercBeret
-
+# ratbite adds
+  - PirateHat
+  - ZookeeperHead
+# ratbite end
 
 - type: loadoutGroup
   id: PassengerFace
@@ -356,6 +364,7 @@
   minLimit: 0
   loadouts:
   - PassengerWintercoat
+  - PirateCoat #ratbite
 
 - type: loadoutGroup
   id: PassengerShoes

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -76,7 +76,7 @@
   equipment:
     #jumpsuit: ClothingUniformJumpsuitSafari
     #head: ClothingHeadSafari
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesBootsWork
     id: ZookeeperPDA
     ears: ClothingHeadsetService
   #storage:


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I added zookeeper, boxer, and pirate clothes to the passenger loadout. I also add an eyepatch to the glasses loadout tab and gave zookeepers workboots by default.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zookeeper is only mapped on one station and boxer isn't mapped on any of them, so allowing passengers to pick the clothing for these jobs might encourage them to get these jobs at the HoP. Also pirate clothes are cool. Zookeeper spawning with workboots feels intended as they get those in their locker at round start.

Pirate clothes for passengers were requested here: https://discord.com/channels/1386740877837471765/1543377618009591919
## Technical details
<!-- Summary of code changes for easier review. -->
I added a few new loadouts and set them to be available for passengers, and I tweaked the loadout for zookeeper.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="211" height="350" alt="image" src="https://github.com/user-attachments/assets/0f00e7e8-1c47-46a5-ba7c-65b69fef4dc4" />
<img width="186" height="341" alt="image" src="https://github.com/user-attachments/assets/36bf6a8e-4336-486c-abc9-81ff49f4c3fa" />
<img width="205" height="331" alt="image" src="https://github.com/user-attachments/assets/7b4017c0-5d7d-46a8-9e98-e05109c1683b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [X] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added pirate outfit to passenger loadout
- add: Added zookeeper outfit to passenger loadout
- add: Added boxer outfits to passenger loadout
- add: Added pirate eyepatch to glasses loadout
- tweak: Tweaked zookeeper loadout to spawn with workboots