### PR TITLE
Fix cryosickness pacifism and misprediction

### DIFF
--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessComponent.cs
@@ -19,9 +19,6 @@ public sealed partial class CryoSicknessComponent : Component
     public EntProtoId Action = "ActionShakeAwake";
 
     [DataField]
-    public ProtoId<StatusEffectPrototype> Effect = "Pacified";
-
-    [DataField]
     public float DamageResistance = 0.6f;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
+++ b/Content.Shared/_BRatbite/CryoSickness/CryoSicknessSystem.cs
@@ -4,10 +4,8 @@ using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.GameTicking;
-using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
 using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -19,8 +17,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly TagSystem _tagSystem = default!;
 
@@ -61,9 +57,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
             var duration = TimeSpan.FromMinutes(ent.Comp.DurationInMinutes);
             ent.Comp.ExpireTime = _timing.CurTime + duration;
             ent.Comp.HadPacifism = HasComp<PacifiedComponent>(ent);
-
-            if (!_statusEffectsSystem.HasStatusEffect(ent.Owner, ent.Comp.Effect))
-                _statusEffectsSystem.TryAddStatusEffect(ent.Owner, ent.Comp.Effect, duration, true, new PacifiedComponent());
         }
 
         EnsureComp<PacifiedComponent>(ent);
@@ -81,7 +74,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         if (LifeStage(ent) >= EntityLifeStage.Terminating) return;
         if (!ent.Comp.HadPacifism)
         {
-            _statusEffectsSystem.TryRemoveStatusEffect(ent.Owner, ent.Comp.Effect);
             RemComp<PacifiedComponent>(ent);
         }
         _popup.PopupClient(Loc.GetString("cryosickness-end-popup"), ent.Owner, ent.Owner);
@@ -109,7 +101,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         if ((args.DamageDelta?.GetTotal() ?? 0) < ent.Comp.MinDamageBeforeRemove && args.Damageable.Damage.GetTotal() < ent.Comp.MinTotalDamageBeforeRemove) return;
         if (!ent.Comp.HadPacifism)
         {
-            _statusEffectsSystem.TryRemoveStatusEffect(ent.Owner, ent.Comp.Effect);
             if (RemComp<PacifiedComponent>(ent))
             {
                 // I'm not completely sold if it should be removed
@@ -128,7 +119,6 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
         if (newTime < ent.Comp.ExpireTime)
         {
             ent.Comp.ExpireTime = newTime;
-
         }
 
         if (args.Origin is null) return;
@@ -168,7 +158,7 @@ public abstract class SharedCryoSicknessSystem : EntitySystem
             return;
 
         // Allow defending against non-player mobs/entities while keeping cryo PvP protection.
-        if (!_mind.TryGetMind(target, out _, out _))
+        if (!_tagSystem.HasTag(ent, _cryoSicknessTag))
             args.Cancel();
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Fix cryo sickness pacifism being removed after 15 minutes even on people who already had pacifism.
Change cryo sickness pacifism to allow hitting people who have never had cryosickness or was removed as originally intended.
Fixes #533
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The current implementation of checking the mind is very buggy because the client does not have mind information, leading to mispredicting the pacifism on every entity. This leads many people, including myself, to immediately remove their cryosickness on roles where fast reaction times are required, as you can't afford to hit your target 10 times before realizing none of your hits were registered because you had cryo sickness.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- As Goobstation is moving to Goob Reforged, we'll be changing licenses. Checking this makes it easier on maints and we won't have to ask every contrib one by one. -->
- [ ] I allow my code and changes to be relicensed to [`GAG v1.0`](https://github.com/Goob-Station/Goob-Reforged/blob/master/LICENSE.MD), upon them being ported to [GoobStation Reforged](https://github.com/Goob-Station/Goob-Reforged) in the near future.
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cryo sick individuals can hit people who have never had pacifism instead of based on mind information
- fix: Cryo sickness pacifism removal when already pacified
