### PR TITLE
trauma explosives take 4, vestine edition

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/reagents/goon.ftl
+++ b/Resources/Locale/en-US/_Goobstation/reagents/goon.ftl
@@ -1,5 +1,4 @@
 reagent-name-formaldehyde = formaldehyde
 reagent-desc-formaldehyde =
-    Inject into a corpse to prevent decomposition.
-    The high chance of decaying into histamine makes it a really mean poison if you want to use it that way.
+    A toxic chemical used in preserving corpses and manufacturing explosives.
     Also prevents the wraith's absorption ability when the corpse has at least 25 units inside it.

--- a/Resources/Locale/en-US/_Trauma/reagents/meta/chemicals.ftl
+++ b/Resources/Locale/en-US/_Trauma/reagents/meta/chemicals.ftl
@@ -1,0 +1,35 @@
+reagent-name-potassium-sulfate = potassium sulfate
+reagent-desc-potassium-sulfate = Potassium in a water-soluble form, providing both potassium and sulfur. Used primarily as a fertilizer for plants.
+
+reagent-name-sodium-bicarbonate = sodium bicarbonate
+reagent-desc-sodium-bicarbonate = A white, odorless, water-soluble salt that has a wide range of uses.  Also known as baking soda.
+
+reagent-name-sodium-acetate = sodium acetate
+reagent-desc-sodium-acetate = A white, odorless, water-soluble salt that results from mixing vinegar and baking soda.
+
+reagent-name-methane = methane
+reagent-desc-methane = A colorless, odorless, and flammable gas, being the simplest alkane. Do not breath.
+
+reagent-name-methanol = methanol
+reagent-desc-methanol = A colorless, odorless, and flammable liquid similar to ethanol however, it is extra toxic.
+
+reagent-name-hexamine = hexamine
+reagent-desc-hexamine = A white crystalline solid that smells fishy. Used in making explosives.
+
+reagent-name-cyclonite = cyclonite
+reagent-desc-cyclonite = A yellowish crystal that is used in plastic explosives. Also known as RDX. This reaction is exothermic. Explodes at 576K.
+
+reagent-name-ammonium-nitrate = ammonium nitrate
+reagent-desc-ammonium-nitrate = A white, crystalline solid that is highly soluble in water. It is a potent fertilizer.
+
+reagent-name-ethenone = ethenone
+reagent-desc-ethenone = A colorless, flammable gas with a penetrating odor. Also known as ketene.
+
+reagent-name-acetic-anhydride = acetic anhydride
+reagent-desc-acetic-anhydride = A colorless liquid that smells like vinegar. Used in manufacturing explosives.
+
+reagent-name-ammonium-nitrate-fuel-oil = ammonium nitrate fuel oil
+reagent-desc-ammonium-nitrate-fuel-oil = An off white, crystalline solid mixed with fuel often used as a blasting agent. Explodes at 576K.
+
+reagent-name-octogen = octogen
+reagent-desc-octogen = A white, opaque powder that has detonation velocity similar to re-entry speeds. Also known as HMX. Explodes at 553K.

--- a/Resources/Locale/en-US/_Trauma/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/_Trauma/reagents/meta/toxins.ftl
@@ -1,0 +1,3 @@
+﻿reagent-name-nitric-acid = nitric acid
+reagent-desc-nitric-acid = A corrosive chemical used in the production of explosives.
+

--- a/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/medicine.yml
@@ -1418,19 +1418,22 @@
   group: Medicine
   desc: reagent-desc-formaldehyde
   physicalDesc: reagent-physical-desc-thick
-  flavor: medicine
+  flavor: strange
   color: "#FFA500"
   worksOnTheDead: true
   metabolisms:
     Poison:
-      metabolismRate: 0.05
+      metabolismRate: 0.03 # Trauma - harder to make, buffed to 33s/u
       effects:
       - !type:HealthChange
+        conditions: # Trauma - this shouldn't be a magic RR unless liver transplant chem
+          - !type:MobStateCondition
+            mobstate: Alive
         damage:
           types:
-            Poison: 0.5
+            Poison: 0.1 # Trauma
     Medicine:
-      metabolismRate: 0.05
+      metabolismRate: 0.03
       effects:
       - !type:ReduceRotting
         seconds: 1

--- a/Resources/Prototypes/_Goobstation/Reagents/pyrotechnics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/pyrotechnics.yml
@@ -7,7 +7,7 @@
   desc: reagent-desc-blackpowder
   flavor: gunpowder
   physicalDesc: reagent-physical-desc-grainy
-# we havent upstreamed yet  contrabandSeverity: Major # explosive, with no other functions
+  contrabandSeverity: Major # explosive, with no other functions
   color: black
   metabolisms:
     Poison:

--- a/Resources/Prototypes/_Goobstation/Reagents/pyrotechnics.yml
+++ b/Resources/Prototypes/_Goobstation/Reagents/pyrotechnics.yml
@@ -7,6 +7,7 @@
   desc: reagent-desc-blackpowder
   flavor: gunpowder
   physicalDesc: reagent-physical-desc-grainy
+# we havent upstreamed yet  contrabandSeverity: Major # explosive, with no other functions
   color: black
   metabolisms:
     Poison:

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/botany.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/botany.yml
@@ -34,5 +34,5 @@
     Nitrogen:
       amount: 1
   products:
-    Saltpeter: 1
+    Saltpeter: 2 # Trauma - Can we all admit a 3:1 yield sucks? Also done to make nitric acid less painful to make
     Water: 1

--- a/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Reactions/medicine.yml
@@ -415,17 +415,19 @@
 
 # Wraith
 - type: reaction
-  minTemp: 424
   id: Formaldehyde
+  minTemp: 357 # trauma - temp, reactants, and products adjusted with explosives PR
   reactants:
-    Ethanol:
+    Methanol:
       amount: 1
-    Iron:
+    Oxygen:
       amount: 1
     Silver:
       amount: 1
+      catalyst: true
   products:
-    Formaldehyde: 2
+    Formaldehyde: 1
+    Water: 1
 
 # Viro
 - type: reaction

--- a/Resources/Prototypes/_Trauma/Reagents/botany.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/botany.yml
@@ -1,0 +1,41 @@
+- type: reagent
+  id: PotassiumSulfate
+  name: reagent-name-potassium-sulfate
+  group: Botanical
+  desc: reagent-desc-potassium-sulfate
+  flavor: bitter
+  physicalDesc: reagent-physical-desc-chalky
+  color: "#c9c3c3"
+  plantMetabolism:
+    - !type:PlantAdjustNutrition
+      amount: 6 # similar to potash but has sulfur, hard to make anyways
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+#        conditions: i majorly cannot be assed to fix this specifically
+#        - !type:MetabolizerTypeCondition
+#          type: [ Plant ]
+
+- type: reagent
+  id: AmmoniumNitrate
+  name: reagent-name-ammonium-nitrate
+  group: Botanical
+  desc: reagent-desc-ammonium-nitrate
+  physicalDesc: reagent-physical-desc-odorless
+  flavor: bitter
+  color: white
+  meltingPoint: 442.8
+  boilingPoint: 483
+  plantMetabolism:
+    - !type:PlantAdjustNutrition
+      amount: 1
+    - !type:PlantAdjustHealth
+      amount: 0.5
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Caustic: 1

--- a/Resources/Prototypes/_Trauma/Reagents/chemicals.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/chemicals.yml
@@ -1,0 +1,70 @@
+- type: reagent
+  id: SodiumBicarbonate
+  name: reagent-name-sodium-bicarbonate
+  desc: reagent-desc-sodium-bicarbonate
+  physicalDesc: reagent-physical-desc-powdery
+  color: white
+
+- type: reagent
+  id: SodiumAcetate
+  name: reagent-name-sodium-acetate
+  desc: reagent-desc-sodium-acetate
+  physicalDesc: reagent-physical-desc-powdery
+  color: white
+  flavor: salty
+  boilingPoint: 1154.4
+  meltingPoint: 597
+
+- type: reagent
+  id: Methane
+  name: reagent-name-methane
+  desc: reagent-desc-methane
+  physicalDesc: reagent-physical-desc-gaseous
+  flavor: bitter
+  color: "#c4f5ff"
+  boilingPoint: 111.5
+  meltingPoint: 90.5
+  metabolisms:
+    Poison:
+      metabolismRate: 0.5
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Asphyxiation: 1.5
+
+- type: reagent
+  id: Ethenone
+  name: reagent-name-ethenone
+  desc: reagent-desc-ethenone
+  physicalDesc: reagent-physical-desc-gaseous
+  flavor: bitter
+  color: "#c4f5ff"
+  boilingPoint: 223.9
+  meltingPoint: 199.5
+  metabolisms:
+    Poison:
+      metabolismRate: 0.5
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Caustic: 1
+
+- type: reagent
+  id: AceticAnhydride
+  name: reagent-name-acetic-anhydride
+  desc: reagent-desc-acetic-anhydride
+  physicalDesc: reagent-physical-desc-sour
+  flavor: sour
+  color: tan
+  boilingPoint: 412.8
+  meltingPoint: 199.9
+  metabolisms:
+    Poison:
+      metabolismRate: 0.5
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Caustic: 1

--- a/Resources/Prototypes/_Trauma/Reagents/pyrotechnics.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/pyrotechnics.yml
@@ -1,0 +1,92 @@
+- type: reagent
+  id: Methanol
+  name: reagent-name-methanol
+  group: Pyrotechnic
+  desc: reagent-desc-methanol
+  physicalDesc: reagent-physical-desc-pungent
+  color: "#c4f5ff"
+  metabolisms:
+    Poison:
+      metabolismRate: 0.5
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        damage:
+          types: # methanol is bad for your health
+            Poison: 3
+
+- type: reagent
+  id: Hexamine
+  name: reagent-name-hexamine
+  group: Pyrotechnic
+  desc: reagent-desc-hexamine
+  flavor: sweet
+  physicalDesc: reagent-physical-desc-crystalline
+# we havent upstreamed yet contrabandSeverity: Major # not explosive, but it's only use is for explosives
+  color: white
+
+- type: reagent
+  id: Cyclonite
+  name: reagent-name-cyclonite
+  group: Pyrotechnic
+  desc: reagent-desc-cyclonite
+  flavor: nothing
+  physicalDesc: reagent-physical-desc-crystalline
+#contrabandSeverity: Major # you probably aren't making this or the other explosives with permission from HOS
+  color: "#e0c009"
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        damage:
+          types: # do not eat C4
+            Poison: 3
+
+- type: reagent
+  id: AmmoniumNitrateFuelOil
+  name: reagent-name-ammonium-nitrate-fuel-oil
+  group: Pyrotechnic
+  desc: reagent-desc-ammonium-nitrate-fuel-oil
+  flavor: nothing
+  physicalDesc: reagent-physical-desc-odorless
+#  contrabandSeverity: Major
+  color: white
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        damage:
+          types: # Oil is not good
+            Poison: 1
+
+- type: reagent
+  id: Octogen
+  name: reagent-name-octogen
+  group: Pyrotechnic
+  desc: reagent-desc-octogen
+  flavor: nothing
+  physicalDesc: reagent-physical-desc-crystalline
+#contrabandSeverity: Major
+  color: white
+  metabolisms:
+    Poison:
+      effects:
+      - !type:HealthChange
+        conditions:
+        - !type:OrganType
+          type: Yowie
+          shouldHave: false
+        damage:
+          types: # do not eat C4's bigger brother
+            Poison: 2

--- a/Resources/Prototypes/_Trauma/Reagents/pyrotechnics.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/pyrotechnics.yml
@@ -11,9 +11,9 @@
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
-          type: Yowie
-          shouldHave: false
+        - !type:MetabolizerTypeCondition
+          type: [ Yowie ]
+          inverted: true
         damage:
           types: # methanol is bad for your health
             Poison: 3
@@ -25,7 +25,7 @@
   desc: reagent-desc-hexamine
   flavor: sweet
   physicalDesc: reagent-physical-desc-crystalline
-# we havent upstreamed yet contrabandSeverity: Major # not explosive, but it's only use is for explosives
+  contrabandSeverity: Major # not explosive, but it's only use is for explosives
   color: white
 
 - type: reagent
@@ -35,16 +35,16 @@
   desc: reagent-desc-cyclonite
   flavor: nothing
   physicalDesc: reagent-physical-desc-crystalline
-#contrabandSeverity: Major # you probably aren't making this or the other explosives with permission from HOS
+  contrabandSeverity: Major # you probably aren't making this or the other explosives with permission from HOS
   color: "#e0c009"
   metabolisms:
     Poison:
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
-          type: Yowie
-          shouldHave: false
+        - !type:MetabolizerTypeCondition
+          type: [ Yowie ]
+          inverted: true
         damage:
           types: # do not eat C4
             Poison: 3
@@ -56,16 +56,16 @@
   desc: reagent-desc-ammonium-nitrate-fuel-oil
   flavor: nothing
   physicalDesc: reagent-physical-desc-odorless
-#  contrabandSeverity: Major
+  contrabandSeverity: Major
   color: white
   metabolisms:
     Poison:
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
-          type: Yowie
-          shouldHave: false
+        - !type:MetabolizerTypeCondition
+          type: [ Yowie ]
+          inverted: true
         damage:
           types: # Oil is not good
             Poison: 1
@@ -77,16 +77,16 @@
   desc: reagent-desc-octogen
   flavor: nothing
   physicalDesc: reagent-physical-desc-crystalline
-#contrabandSeverity: Major
+  contrabandSeverity: Syndicate
   color: white
   metabolisms:
     Poison:
       effects:
       - !type:HealthChange
         conditions:
-        - !type:OrganType
-          type: Yowie
-          shouldHave: false
+        - !type:MetabolizerTypeCondition
+          type: [ Yowie ]
+          inverted: true
         damage:
           types: # do not eat C4's bigger brother
             Poison: 2

--- a/Resources/Prototypes/_Trauma/Reagents/toxins.yml
+++ b/Resources/Prototypes/_Trauma/Reagents/toxins.yml
@@ -1,0 +1,45 @@
+- type: reagent
+  id: NitricAcid
+  name: reagent-name-nitric-acid
+  group: Toxins
+  desc: reagent-desc-nitric-acid
+  physicalDesc: reagent-physical-desc-abrasive
+  flavor: acid
+  color: "#FAFAFA"
+  boilingPoint: 356
+  meltingPoint: 231
+  plantMetabolism:
+  - !type:PlantAdjustToxins
+    amount: 10
+  - !type:PlantAdjustWeeds
+    amount: -2
+  - !type:PlantAdjustHealth
+    amount: -5
+  reactiveEffects:
+    Acidic:
+      methods: [ Touch ]
+      effects:
+      - !type:HealthChange
+        ignoreResistances: false
+        damage:
+          types:
+            Caustic: 0.1
+      - !type:Emote
+        emote: Scream
+        probability: 0.1
+  metabolisms:
+    Poison:
+      metabolismRate: 3.00 # Okay damage, high metabolism rate. You need a lot of units to crit. Simulates acid burning through you fast.
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Caustic: 4
+      - !type:PopupMessage
+        type: Local
+        visualType: Large
+        messages: [ "generic-reagent-effect-burning-insides" ]
+        probability: 0.33
+      - !type:Emote
+        emote: Scream
+        probability: 0.2

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/botany.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/botany.yml
@@ -1,0 +1,9 @@
+- type: reaction
+  id: AmmoniumNitrate
+  reactants:
+    Ammonia:
+      amount: 1
+    NitricAcid:
+      amount: 1
+  products:
+    AmmoniumNitrate: 2

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/chemicals.yml
@@ -1,0 +1,62 @@
+- type: reaction
+  id: SodiumBicarbonate
+  reactants:
+    SodiumCarbonate:
+      amount: 1
+    Water:
+      amount: 1
+    Carbon:
+      amount: 1
+    Oxygen:
+      amount: 2
+  products:
+    SodiumBicarbonate: 5
+
+- type: reaction
+  id: SodiumAcetate
+  reactants:
+    SodiumBicarbonate:
+      amount: 1
+    Vinegar:
+      amount: 1
+  products:
+    SodiumAcetate: 1
+    CarbonDioxide: 1
+    Water: 1
+
+- type: reaction
+  id: Methane
+  reactants:
+    CarbonDioxide:
+      amount: 1
+    Hydrogen:
+      amount: 4
+    Aluminium:
+      amount: 1
+      catalyst: true
+  products:
+    Methane: 3
+    Water: 2
+
+- type: reaction
+  id: CarbonCombustion
+  minTemp: 773
+  reactants:
+    Carbon:
+      amount: 1
+    Oxygen:
+      amount: 1
+  products:
+    CarbonDioxide: 2
+
+- type: reaction
+  id: AceticAnhydride
+  minTemp: 323
+  reactants:
+    Vinegar:
+      amount: 1
+    Ethenone:
+      amount: 1
+  products:
+    AceticAnhydride: 1
+    Water: 1

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/pyrotechnics.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/pyrotechnics.yml
@@ -1,0 +1,56 @@
+- type: reaction
+  id: Methanol
+  reactants:
+    Methane:
+      amount: 1
+    Water:
+      amount: 1
+    Oxygen:
+      amount: 1
+  products:
+    Methanol: 3
+
+- type: reaction
+  id: Hexamine
+  reactants:
+    Formaldehyde:
+      amount: 3
+    Ammonia:
+      amount: 2
+  products:
+    Hexamine: 5
+
+- type: reaction
+  id: Cyclonite
+  reactants:
+    Hexamine:
+      amount: 1
+    NitricAcid:
+      amount: 1
+  products:
+    Cyclonite: 2
+
+- type: reaction
+  id: AmmoniumNitrateFuelOil
+  reactants:
+    AmmoniumNitrate:
+      amount: 2
+    WeldingFuel:
+      amount: 1
+  products:
+    AmmoniumNitrateFuelOil: 2
+
+- type: reaction
+  id: Octogen
+  priority: 5 # god please let this react BEFORE cyclonite
+  reactants:
+    NitricAcid:
+      amount: 1
+    Vinegar:
+      amount: 1
+    AceticAnhydride:
+      amount: 1
+    Hexamine:
+      amount: 1
+  products:
+    Octogen: 4

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/pyrotechnics.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/pyrotechnics.yml
@@ -52,5 +52,7 @@
       amount: 1
     Hexamine:
       amount: 1
+    Vestine:
+      amount: 1
   products:
-    Octogen: 4
+    Octogen: 5

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
@@ -1,0 +1,85 @@
+- type: reaction
+  id: CycloniteExplosion
+  minTemp: 576 #todo: make the reaction require another explosion to detonate it.
+  impact: High
+  priority: 20
+  reactants:
+    Cyclonite:
+      amount: 1
+  products:
+    Ash: 0.1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: DemolitionCharge #Better at breaking walls and stuff
+      maxIntensity: 50
+      intensityPerUnit: 7 # RDX's RE factor is 1.6 of tnt
+      intensitySlope: 20 # more controlled explosion
+      maxTotalIntensity: 700
+
+- type: reaction
+  id: AmmoniumNitrateDecomposition
+  minTemp: 484
+  reactants:
+    AmmoniumNitrate:
+      amount: 2
+  products:
+    Nitrogen: 2
+    Oxygen: 1
+    Water: 4
+
+- type: reaction
+  id: SodiumBicarbonateDecomposition
+  minTemp: 324
+  reactants:
+    SodiumBicarbonate:
+      amount: 2
+  products:
+    SodiumCarbonate: 2
+    CarbonDioxide: 1
+    Water: 1
+
+- type: reaction
+  id: ANFOExplosion
+  minTemp: 576 #todo: make the reaction require another explosion to detonate it.
+  impact: High
+  priority: 20
+  reactants:
+    AmmoniumNitrateFuelOil:
+      amount: 1
+  products:
+    Ash: 0.1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: DemolitionCharge #ANFO is used in mining
+      maxIntensity: 12
+      intensityPerUnit: 3 # you need a lot of it for a large explosion
+      intensitySlope: 1
+      maxTotalIntensity: 3000 # max explosion requires 5000 units which is A LOT
+
+- type: reaction
+  id: VinegarDecomposition
+  minTemp: 504
+  reactants:
+    Vinegar:
+      amount: 1
+  products:
+    Ethenone: 1
+    Water: 1
+
+- type: reaction
+  id: OctogenExplosion
+  minTemp: 553 #todo: make the reaction require another explosion to detonate it.
+  impact: High
+  priority: 20
+  reactants:
+    Octogen:
+      amount: 1
+  products:
+    Ash: 0.1
+  effects:
+    - !type:ExplosionReactionEffect
+      explosionType: HardBomb # very high detonation velocity
+      maxIntensity: 20
+      intensityPerUnit: 3 # Lower because hardbomb
+      intensitySlope: 2 # very high detonation velocity
+      maxTotalIntensity: 3000 # very high detonation velocity # this sounds horrifying, but we'll just have to see whether it should be tweaked - Speebro

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/single_reagent.yml
@@ -9,7 +9,7 @@
   products:
     Ash: 0.1
   effects:
-    - !type:ExplosionReactionEffect
+    - !type:Explosion
       explosionType: DemolitionCharge #Better at breaking walls and stuff
       maxIntensity: 50
       intensityPerUnit: 7 # RDX's RE factor is 1.6 of tnt
@@ -49,7 +49,7 @@
   products:
     Ash: 0.1
   effects:
-    - !type:ExplosionReactionEffect
+    - !type:Explosion
       explosionType: DemolitionCharge #ANFO is used in mining
       maxIntensity: 12
       intensityPerUnit: 3 # you need a lot of it for a large explosion
@@ -77,7 +77,7 @@
   products:
     Ash: 0.1
   effects:
-    - !type:ExplosionReactionEffect
+    - !type:Explosion
       explosionType: HardBomb # very high detonation velocity
       maxIntensity: 20
       intensityPerUnit: 3 # Lower because hardbomb

--- a/Resources/Prototypes/_Trauma/Recipes/Reactions/toxins.yml
+++ b/Resources/Prototypes/_Trauma/Recipes/Reactions/toxins.yml
@@ -1,0 +1,12 @@
+﻿- type: reaction
+  id: NitricAcid
+  impact: Medium
+  minTemp: 357
+  reactants:
+    Saltpeter:
+      amount: 2
+    SulfuricAcid:
+      amount: 1
+  products:
+    NitricAcid: 2
+    PotassiumSulfate: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license.
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license.
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Bombs. Incase I gotta throw one, like Fortnite.

Surely they stay in *this* time.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously removed with no real comment besides "Untested" (likely due to octogen). Goobstation decided locking it behind vestine was a good idea, and considering vestine is locked behind two impossibilities, those being a traitor with competent chemistry knowledge OR science actually getting something done with their hours on station, I feel it's safe enough to keep.
## Technical details
<!-- Summary of code changes for easier review. -->
git cherry-pick content
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Cuban Pete
- add: TraumaStation's Explosive chemicals are back once again, see the Guidebook for "Octogen" and "Cyclonite" for more details.
